### PR TITLE
Refactor intrinsic functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,13 +268,14 @@ A real functional testing example using Pytest can be seen [here](./tests/test_c
 - Easier to pick regions for testing
 
 ### Unit
-- Implement all AWS [intrinsic functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html).
-  * Only `!Ref`, `!Sub`, `!Equals` and `!If` currently supported.
 - Add full functionality to pseudo variables.
   * Variables like `Partition`, `URLSuffix` should change if the region changes.
   * Variables like `StackName` and `StackId` should have a better default than ""
 - Handle References to resources that shouldn't exist.
   * It's currently possible that a `!Ref` to a Resource stays in the final template even if that resource is later removed because of a conditional.
+- Handle function order
+  * Some functions restrict which functions can be nested in [them](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#w2ab1c33c28c21c45).
+  * Some functions are only allowed in [certain parts](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html) of the template.
 
 ### Functional
 - Add the ability to update a stack instance to Taskcat.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-
+allow_redefinition = True
 [mypy-nox.*,taskcat.*,pytest]
 ignore_missing_imports = True

--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -34,6 +34,8 @@ class Template:
 
         Args:
             template (Dict): The Cloudformation template as a dictionary.
+            imports (Optional[Dict[str, str]], optional): Values this template plans
+            to import from other stacks exports. Defaults to None.
 
         Raises:
             TypeError: If template is not a dictionary.
@@ -44,10 +46,12 @@ class Template:
             imports = {}
 
         if not isinstance(template, dict):
-            raise TypeError(f"Template should be dict not {type(template).__name__}.")
+            raise TypeError(
+                f"Template should be a dict, not {type(template).__name__}."
+            )
 
         if not isinstance(imports, dict):
-            raise TypeError(f"Imports should be dict not {type(imports).__name__}.")
+            raise TypeError(f"Imports should be a dict, not {type(imports).__name__}.")
 
         self.raw: str = yaml.dump(template)
         self.template = template
@@ -55,7 +59,19 @@ class Template:
         self.imports = imports
 
     @classmethod
-    def from_yaml(cls, template_path: Union[str, Path]) -> Template:
+    def from_yaml(
+        cls, template_path: Union[str, Path], imports: Optional[Dict[str, str]] = None
+    ) -> Template:
+        """Loads a Cloudformation template from file.
+
+        Args:
+            template_path (Union[str, Path]): The path to the template.
+            imports (Optional[Dict[str, str]], optional): Values this template plans
+            to import from other stacks exports. Defaults to None.
+
+        Returns:
+            Template: A Template object ready for testing.
+        """
 
         with open(template_path) as f:
             raw = f.read()
@@ -66,7 +82,7 @@ class Template:
 
         template = yaml.load(tmp_str, Loader=yaml.FullLoader)
 
-        return cls(template)
+        return cls(template, imports)
 
     def render(
         self, params: Dict[str, str] = None, region: Union[str, None] = None

--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from cfn_tools import dump_yaml, load_yaml  # type: ignore
 
@@ -26,7 +26,9 @@ class Template:
     StackName: str = ""  # Not yet implemented
     URLSuffix: str = "amazonaws.com"  # Other regions not implemented
 
-    def __init__(self, template: Dict[str, Any]) -> None:
+    def __init__(
+        self, template: Dict[str, Any], imports: Optional[Dict[str, str]] = None
+    ) -> None:
         """Loads a Cloudformation template from a file and saves
         it as a dictionary.
 
@@ -35,14 +37,22 @@ class Template:
 
         Raises:
             TypeError: If template is not a dictionary.
+            TypeError: If imports is not a dictionary.
         """
+
+        if imports is None:
+            imports = {}
 
         if not isinstance(template, dict):
             raise TypeError(f"Template should be dict not {type(template).__name__}.")
 
+        if not isinstance(imports, dict):
+            raise TypeError(f"Imports should be dict not {type(imports).__name__}.")
+
         self.raw: str = yaml.dump(template)
         self.template = template
         self.Region = Template.Region
+        self.imports = imports
 
     @classmethod
     def from_yaml(cls, template_path: Union[str, Path]) -> Template:

--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -120,6 +120,9 @@ class Template:
                 if key == "Fn::Sub":
                     return functions.sub(self, value)
 
+                if key == "Fn::Join":
+                    return functions.join(value)
+
                 data[key] = self.resolve_values(value)
             return data
         elif isinstance(data, list):

--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -123,6 +123,12 @@ class Template:
                 if key == "Fn::Join":
                     return functions.join(value)
 
+                # if key == "Fn::Base64":
+                #     return functions.base64(value)
+
+                # if key == "Fn::Cidr":
+                #     return functions.cidr(value)
+
                 data[key] = self.resolve_values(value)
             return data
         elif isinstance(data, list):

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -5,7 +5,7 @@ and Condition functions.
 """
 
 import re
-from typing import Any, Dict, TYPE_CHECKING, Union
+from typing import Any, Dict, List, TYPE_CHECKING, Union
 
 
 if TYPE_CHECKING:
@@ -46,6 +46,35 @@ def if_(template: Dict, function: list) -> Any:
         return function[1]
 
     return function[2]
+
+
+def join(value: Any) -> str:
+
+    delimiter: str
+    items: List[str]
+
+    if not isinstance(value, list):
+        raise Exception(
+            f"The value for !Join or Fn::Join must be list not {type(value).__name__}."
+        )
+
+    if not len(value) == 2:
+        raise Exception(
+            (
+                "The value for !Join or Fn::Join must contain "
+                "a delimiter and a list of items to join."
+            )
+        )
+
+    if isinstance(value[0], str) and isinstance(value[1], list):
+        delimiter = value[0]
+        items = value[1]
+    else:
+        raise Exception(
+            "The first value for !Join or Fn::Join must be a String and the second a List."
+        )
+
+    return delimiter.join(items)
 
 
 def ref(template: "Template", var_name: str) -> Union[str, int, float, list]:

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -12,10 +12,10 @@ from typing import Any, Dict, List, TYPE_CHECKING
 
 import requests
 
-REGION_DATA = None
-
 if TYPE_CHECKING:
     from ._template import Template
+
+REGION_DATA = None
 
 
 def base64(_t: "Template", value: Any) -> str:
@@ -242,6 +242,34 @@ def or_(_t: "Template", values: Any) -> bool:
         raise ValueError("Fn::Not - The values must have between 2 and 10 conditions.")
 
     return any(values)
+
+
+def condition(template: "Template", name: Any) -> bool:
+    """Solves AWS Condition function.
+
+    Args:
+        template (Template): The template being tested.
+        name (Any): The name of the condition.
+
+    Raises:
+        TypeError: If name is not a String.
+        KeyError: If name not found in template conditions.
+
+    Returns:
+        bool: The value of the condition.
+    """
+
+    if not isinstance(name, str):
+        raise TypeError(
+            f"Fn::Condition - The value must be a String, not {type(name).__name__}."
+        )
+
+    if name not in template.template["Conditions"]:
+        raise KeyError(
+            f"Fn::Condition - Unable to find condition '{name}' in template."
+        )
+
+    return template.template["Conditions"][name]
 
 
 def find_in_map(template: "Template", values: Any) -> Any:

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -48,12 +48,12 @@ def if_(template: Dict, function: list) -> Any:
     return function[2]
 
 
-def ref(template: "Template", vaname: str) -> Union[str, int, float, list]:
+def ref(template: "Template", var_name: str) -> Union[str, int, float, list]:
     """Takes the name of a parameter, resource or pseudo variable and finds the value for it.
 
     Args:
         template (Dict): The Cloudformation template.
-        vaname (str): The name of the parameter, resource or pseudo variable.
+        var_name (str): The name of the parameter, resource or pseudo variable.
 
     Raises:
         ValueError: If the supplied pseudo variable doesn't exist.
@@ -62,8 +62,8 @@ def ref(template: "Template", vaname: str) -> Union[str, int, float, list]:
         Union[str, int, float, list]: The value of the parameter, resource or pseudo variable.
     """
 
-    if "AWS::" in vaname:
-        pseudo = vaname.replace("AWS::", "")
+    if "AWS::" in var_name:
+        pseudo = var_name.replace("AWS::", "")
 
         # Can't treat region like a normal pseduo because
         # we don't want to update the class var for every run.
@@ -72,12 +72,12 @@ def ref(template: "Template", vaname: str) -> Union[str, int, float, list]:
         try:
             return getattr(template, pseudo)
         except AttributeError:
-            raise ValueError(f"Unrecognized AWS Pseduo variable: '{vaname}'.")
+            raise ValueError(f"Unrecognized AWS Pseduo variable: '{var_name}'.")
 
-    if vaname in template.template["Parameters"]:
-        return template.template["Parameters"][vaname]["Value"]
+    if var_name in template.template["Parameters"]:
+        return template.template["Parameters"][var_name]["Value"]
     else:
-        return vaname
+        return var_name
 
 
 def sub(template: "Template", function: str) -> str:

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -7,14 +7,14 @@ and Condition functions.
 import base64 as b64
 import ipaddress
 import re
-from typing import Any, Dict, List, TYPE_CHECKING, Union
+from typing import Any, List, TYPE_CHECKING, Union
 
 
 if TYPE_CHECKING:
     from ._template import Template
 
 
-def base64(value: Any) -> str:
+def base64(_t: "Template", value: Any) -> str:
 
     if not isinstance(value, str):
         raise Exception(
@@ -26,7 +26,7 @@ def base64(value: Any) -> str:
     return b_string.decode("ascii")
 
 
-def cidr(value: Any) -> List[str]:
+def cidr(_t: "Template", value: Any) -> List[str]:
 
     if not isinstance(value, list):
         raise Exception(
@@ -59,7 +59,7 @@ def cidr(value: Any) -> List[str]:
         )
 
 
-def equals(function: list) -> bool:
+def equals(_t: "Template", function: list) -> bool:
     """Solves AWS Equals intrinsic functions.
 
     Args:
@@ -72,7 +72,7 @@ def equals(function: list) -> bool:
     return function[0] == function[1]
 
 
-def if_(template: Dict, function: list) -> Any:
+def if_(template: "Template", function: list) -> Any:
     """Solves AWS If intrinsic functions.
 
     Args:
@@ -87,7 +87,7 @@ def if_(template: Dict, function: list) -> Any:
     if type(condition) is not str:
         raise Exception(f"AWS Condition should be str, not {type(condition).__name__}.")
 
-    condition = template["Conditions"][condition]
+    condition = template.template["Conditions"][condition]
 
     if condition:
         return function[1]
@@ -95,7 +95,7 @@ def if_(template: Dict, function: list) -> Any:
     return function[2]
 
 
-def join(value: Any) -> str:
+def join(_t: "Template", value: Any) -> str:
 
     delimiter: str
     items: List[str]

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -4,12 +4,25 @@ This module contains the logic to solve both AWS Intrinsic
 and Condition functions.
 """
 
+import base64 as b64
 import re
 from typing import Any, Dict, List, TYPE_CHECKING, Union
 
 
 if TYPE_CHECKING:
     from ._template import Template
+
+
+def base64(value: Any) -> str:
+
+    if not isinstance(value, str):
+        raise Exception(
+            f"The value for !Base64 or Fn::Base64 must be a String, not {type(value).__name__}."
+        )
+
+    b_string = b64.b64encode(value.encode("ascii"))
+
+    return b_string.decode("ascii")
 
 
 def equals(function: list) -> bool:
@@ -38,7 +51,7 @@ def if_(template: Dict, function: list) -> Any:
     condition = function[0]
 
     if type(condition) is not str:
-        raise Exception(f"AWS Condition should be str not {type(condition).__name__}.")
+        raise Exception(f"AWS Condition should be str, not {type(condition).__name__}.")
 
     condition = template["Conditions"][condition]
 

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -6,9 +6,13 @@ and Condition functions.
 
 import base64 as b64
 import ipaddress
+import json
 import re
 from typing import Any, List, TYPE_CHECKING, Union
 
+import requests
+
+REGION_DATA = None
 
 if TYPE_CHECKING:
     from ._template import Template
@@ -59,40 +63,241 @@ def cidr(_t: "Template", value: Any) -> List[str]:
         )
 
 
-def equals(_t: "Template", function: list) -> bool:
-    """Solves AWS Equals intrinsic functions.
+def and_(_t: "Template", equation: Any) -> bool:
+    raise NotImplementedError("Fn::And had not been implemented.")
+
+
+def equals(_t: "Template", equation: Any) -> bool:
+    """Solves AWS Equals intrinsic function.
 
     Args:
-        function (list): A list with two items to be compared.
+        _t (Template): Not used
+        equation (Any): The equation to be solved.
+
+    Raises:
+        TypeError: If equation is not a list.
+        ValueError: If length of equation is not 2.
 
     Returns:
-        bool: Returns True if the items are equal, else False.
+        bool: True if the values in the equation are equal.
     """
 
-    return function[0] == function[1]
+    if not isinstance(equation, list):
+        raise TypeError(
+            f"Fn::Equals - The equations must be a List, not {type(equation).__name__}."
+        )
+
+    if not len(equation) == 2:
+        raise ValueError(
+            (
+                "The equation for !Equals or Fn::Equals must contain "
+                "two values to compare."
+            )
+        )
+
+    return equation[0] == equation[1]
 
 
-def if_(template: "Template", function: list) -> Any:
+def if_(template: "Template", equation: Any) -> Any:
     """Solves AWS If intrinsic functions.
 
     Args:
-        function (list): The condition, true value and false value.
+        template (Template): The template being tested.
+        equation (Any): The equation to be solved.
+
+    Raises:
+        TypeError: If equation is not a list.
+        ValueError: If length of equation is not 3.
+        TypeError: If the first value in the equation is not str.
 
     Returns:
-        Any: The return value could be another intrinsic function, boolean or string.
+        Any: The result of the equation.
     """
 
-    condition = function[0]
+    if not isinstance(equation, list):
+        raise TypeError(
+            f"The equation for !If or Fn::If must be a List, not {type(equation).__name__}."
+        )
 
-    if type(condition) is not str:
-        raise Exception(f"AWS Condition should be str, not {type(condition).__name__}.")
+    if not len(equation) == 3:
+        raise ValueError(
+            (
+                "The equation for !If or Fn::If must contain "
+                "the name of a condition, a True value and "
+                "a False value."
+            )
+        )
+
+    condition = equation[0]
+
+    if not isinstance(condition, str):
+        raise TypeError(f"AWS Condition should be str, not {type(condition).__name__}.")
 
     condition = template.template["Conditions"][condition]
 
     if condition:
-        return function[1]
+        return equation[1]
 
-    return function[2]
+    return equation[2]
+
+
+def not_(_t: "Template", equation: Any) -> bool:
+    raise NotImplementedError("Fn::Not had not been implemented.")
+
+
+def or_(_t: "Template", equation: Any) -> bool:
+    raise NotImplementedError("Fn::Or had not been implemented.")
+
+
+def find_in_map(template: "Template", equation: Any) -> Any:
+    """Solves AWS FindInMap intrinsic function.
+
+    Args:
+        template (Template): The template being tested.
+        equation (Any): The equation to be solved.
+
+    Raises:
+        TypeError: If equation is not a list.
+        ValueError: If length of equation is not 3.
+        KeyError: If the Map or specified keys are missing.
+
+    Returns:
+        Any: The requested value from the Map.
+    """
+
+    if not isinstance(equation, list):
+        raise TypeError(
+            f"Fn::FindInMap - The equation must be a List, not {type(equation).__name__}."
+        )
+
+    if not len(equation) == 3:
+        raise ValueError(
+            (
+                "The equation for !FindInMap  or Fn::FindInMap  must contain "
+                "a MapName, TopLevelKey and SecondLevelKey."
+            )
+        )
+
+    map_name = equation[0]
+    top_key = equation[1]
+    second_key = equation[2]
+
+    if "Mappings" not in template.template:
+        raise KeyError("Unable to find Mappings section in template.")
+
+    maps = template.template["Mappings"]
+
+    if map_name not in maps:
+        raise KeyError(f"Unable to find {map_name} in Mappings section of template.")
+
+    map = maps[map_name]
+
+    if top_key not in map:
+        raise KeyError(f"Unable to find key {top_key} in map {map_name}.")
+
+    first_level = map[top_key]
+
+    if second_key not in first_level:
+        raise KeyError(f"Unable to find key {second_key} in map {map_name}.")
+
+    return first_level[second_key]
+
+
+def get_att(template: "Template", equation: Any) -> str:
+    """Solves AWS GetAtt intrinsic function.
+
+    Args:
+        template (Template): The template being tested.
+        equation (Any): The equation to be solved.
+
+    Raises:
+        TypeError: If equation is not a list.
+        ValueError: If length of equation is not 3.
+        TypeError: If the logicalNameOfResource and attributeName are not str.
+        KeyError: If the logicalNameOfResource is not found in the template.
+
+    Returns:
+        str: The interpolated str `logicalNameOfResource.attributeName`.
+    """
+
+    if not isinstance(equation, list):
+        raise TypeError(
+            f"Fn::GetAtt - The equation must be a List, not {type(equation).__name__}."
+        )
+
+    if not len(equation) == 2:
+        raise ValueError(
+            (
+                "Fn::GetAtt - The equation must contain "
+                "the logicalNameOfResource and attributeName."
+            )
+        )
+
+    resource_name = equation[0]
+    att_name = equation[1]
+
+    if not isinstance(resource_name, str) or not isinstance(att_name, str):
+        raise TypeError(
+            "Fn::GetAtt - logicalNameOfResource and attributeName must be String."
+        )
+
+    if resource_name not in template.template["Resources"]:
+        raise KeyError(f"Fn::GetAtt - Resource {resource_name} not found in template.")
+
+    return f"{resource_name}.{att_name}"
+
+
+def get_azs(_t: "Template", region: Any) -> List[str]:
+    """Solves AWS GetAZs intrinsic function.
+
+    Args:
+        _t (Template): The template being tested.
+        region (Any): The name of a region.
+
+    Raises:
+        TypeError: If region is not a string.
+
+    Returns:
+        List[str]: The list of AZs for the provided region.
+    """
+
+    if not isinstance(region, str):
+        raise TypeError(
+            f"Fn::GetAZs - The region must be a String, not {type(region).__name__}."
+        )
+
+    return get_region_azs(region)
+
+
+def import_value(template: "Template", name: Any) -> str:
+    """Solves AWS ImportValue intrinsic function.
+
+    Args:
+        template (Template): The template being tested.
+        name (Any): The name of the Export to be Imported.
+
+    Raises:
+        TypeError: If name is not a String.
+        ValueError: If no imports have been configured.
+        KeyError: If name is not found in the imports.
+
+    Returns:
+        str: The value of name from the configured imports.
+    """
+
+    if not isinstance(name, str):
+        raise TypeError(
+            "Fn::ImportValue - The name of the Export "
+            f"should be String, not {type(name).__name__}."
+        )
+
+    if not template.imports:
+        raise ValueError("Fn::ImportValue - No imports have been configued.")
+
+    if name not in template.imports:
+        raise KeyError(f"Fn::ImportValue - {name} not found in the configured imports.")
+
+    return template.imports[name]
 
 
 def join(_t: "Template", value: Any) -> str:
@@ -122,6 +327,40 @@ def join(_t: "Template", value: Any) -> str:
         )
 
     return delimiter.join(items)
+
+
+def select(_t: "Template", equation: Any) -> Any:
+    raise NotImplementedError("Fn::Select has not been implemented.")
+
+
+def split(_t: "Template", equation: Any) -> List[str]:
+    raise NotImplementedError("Fn::Split had not been implemented.")
+
+
+def sub(template: "Template", function: str) -> str:
+    """Solves AWS Sub intrinsic functions.
+
+    Args:
+        function (str): A string with ${} parameters or resources referenced in the template.
+
+    Returns:
+        str: Returns the rendered string.
+    """  # noqa: B950
+
+    def replace_var(m):
+        var = m.group(2)
+        return ref(template, var)
+
+    reVar = r"(?!\$\{\!)\$(\w+|\{([^}]*)\})"
+
+    if re.search(reVar, function):
+        return re.sub(reVar, replace_var, function).replace("${!", "${")
+
+    return function.replace("${!", "${")
+
+
+def transform(template: "Template", equation: Any) -> Any:
+    raise NotImplementedError("Fn::Transform has not been implemented.")
 
 
 def ref(template: "Template", var_name: str) -> Union[str, int, float, list]:
@@ -156,23 +395,27 @@ def ref(template: "Template", var_name: str) -> Union[str, int, float, list]:
         return var_name
 
 
-def sub(template: "Template", function: str) -> str:
-    """Solves AWS Sub intrinsic functions.
+def get_region_azs(region_name: str) -> List[str]:
 
-    Args:
-        function (str): A string with ${} parameters or resources referenced in the template.
+    global REGION_DATA
 
-    Returns:
-        str: Returns the rendered string.
-    """  # noqa: B950
+    if not REGION_DATA:
+        REGION_DATA = _fetch_region_data()
 
-    def replace_var(m):
-        var = m.group(2)
-        return ref(template, var)
+    for region in REGION_DATA:
+        if region["code"] == region_name:
+            return region["zones"]
 
-    reVar = r"(?!\$\{\!)\$(\w+|\{([^}]*)\})"
+    raise Exception(f"Unable to find region {region_name}.")
 
-    if re.search(reVar, function):
-        return re.sub(reVar, replace_var, function).replace("${!", "${")
 
-    return function.replace("${!", "${")
+def _fetch_region_data() -> List[dict]:
+
+    url = "https://raw.githubusercontent.com/jsonmaur/aws-regions/master/regions.json"
+
+    r = requests.get(url)
+
+    if not r.status_code == requests.codes.ok:
+        r.raise_for_status()
+
+    return json.loads(r.text)

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -1,0 +1,102 @@
+"""AWS Intrinsic functions.
+
+This module contains the logic to solve both AWS Intrinsic
+and Condition functions.
+"""
+
+import re
+from typing import Any, Dict, TYPE_CHECKING, Union
+
+
+if TYPE_CHECKING:
+    from ._template import Template
+
+
+def equals(function: list) -> bool:
+    """Solves AWS Equals intrinsic functions.
+
+    Args:
+        function (list): A list with two items to be compared.
+
+    Returns:
+        bool: Returns True if the items are equal, else False.
+    """
+
+    return function[0] == function[1]
+
+
+def if_(template: Dict, function: list) -> Any:
+    """Solves AWS If intrinsic functions.
+
+    Args:
+        function (list): The condition, true value and false value.
+
+    Returns:
+        Any: The return value could be another intrinsic function, boolean or string.
+    """
+
+    condition = function[0]
+
+    if type(condition) is not str:
+        raise Exception(f"AWS Condition should be str not {type(condition).__name__}.")
+
+    condition = template["Conditions"][condition]
+
+    if condition:
+        return function[1]
+
+    return function[2]
+
+
+def ref(template: "Template", vaname: str) -> Union[str, int, float, list]:
+    """Takes the name of a parameter, resource or pseudo variable and finds the value for it.
+
+    Args:
+        template (Dict): The Cloudformation template.
+        vaname (str): The name of the parameter, resource or pseudo variable.
+
+    Raises:
+        ValueError: If the supplied pseudo variable doesn't exist.
+
+    Returns:
+        Union[str, int, float, list]: The value of the parameter, resource or pseudo variable.
+    """
+
+    if "AWS::" in vaname:
+        pseudo = vaname.replace("AWS::", "")
+
+        # Can't treat region like a normal pseduo because
+        # we don't want to update the class var for every run.
+        if pseudo == "Region":
+            return template.template["Metadata"]["Cloud-Radar"]["Region"]
+        try:
+            return getattr(template, pseudo)
+        except AttributeError:
+            raise ValueError(f"Unrecognized AWS Pseduo variable: '{vaname}'.")
+
+    if vaname in template.template["Parameters"]:
+        return template.template["Parameters"][vaname]["Value"]
+    else:
+        return vaname
+
+
+def sub(template: "Template", function: str) -> str:
+    """Solves AWS Sub intrinsic functions.
+
+    Args:
+        function (str): A string with ${} parameters or resources referenced in the template.
+
+    Returns:
+        str: Returns the rendered string.
+    """  # noqa: B950
+
+    def replace_var(m):
+        var = m.group(2)
+        return ref(template, var)
+
+    reVar = r"(?!\$\{\!)\$(\w+|\{([^}]*)\})"
+
+    if re.search(reVar, function):
+        return re.sub(reVar, replace_var, function).replace("${!", "${")
+
+    return function.replace("${!", "${")

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -205,6 +205,27 @@ def test_or(fake_t):
     assert result is False
 
 
+def test_condition():
+
+    template = {"Conditions": {"test": False}}
+
+    template = Template(template)
+
+    with pytest.raises(TypeError) as e:
+        result = functions.condition(template, [])
+
+    assert "String, not list." in str(e)
+
+    with pytest.raises(KeyError) as e:
+        result = functions.condition(template, "Fake")
+
+    assert "Unable to find condition" in str(e)
+
+    result = functions.condition(template, "test")
+
+    assert result is False
+
+
 def test_find_in_map():
     template = {}
 

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -1,0 +1,98 @@
+import inspect
+
+import pytest
+
+from cloud_radar.cf.unit import functions
+from cloud_radar.cf.unit._template import Template, add_metadata
+
+
+def test_ref():
+
+    template = {"Parameters": {"foo": {"Value": "bar"}}}
+
+    add_metadata(template, Template.Region)
+
+    template = Template(template)
+
+    for i in inspect.getmembers(Template):
+        if not i[0].startswith("_"):
+            if isinstance(i[1], str):
+                result = functions.ref(template, f"AWS::{i[0]}")
+                assert (
+                    result == i[1]
+                ), "Should be able to reference all pseudo variables."
+
+    result = functions.ref(template, "foo")
+
+    assert result == "bar", "Should reference parameters."
+
+    result = functions.ref(template, "SomeResource")
+
+    assert (
+        result == "SomeResource"
+    ), "If not a psedo var or parameter it should return the input."
+
+    fake = "AWS::FakeVar"
+
+    with pytest.raises(ValueError) as e:
+        functions.ref(template, fake)
+
+    assert f"Unrecognized AWS Pseduo variable: '{fake}'." in str(e.value)
+
+
+def test_if():
+
+    template = {"Conditions": {"test": False}}
+
+    result = functions.if_(template, ["test", "true_value", "false_value"])
+
+    assert result == "false_value", "Should return the false value."
+
+    template["Conditions"]["test"] = True
+
+    result = functions.if_(template, ["test", "true_value", "false_value"])
+
+    assert result == "true_value", "Should return the true value."
+
+    with pytest.raises((Exception)):
+        # First value should the name of the condition to lookup
+        functions.if_(template, [True, "True", "False"])
+
+
+def test_equals():
+    # AWS is not very clear on what is valid here?
+    # > A value of any type that you want to compare.
+
+    true_lst = [True, "foo", 5, ["test"], {"foo": "foo"}]
+    false_lst = [False, "bar", 10, ["bar"], {"bar": "bar"}]
+
+    for idx, true in enumerate(true_lst):
+        false = false_lst[idx]
+
+        assert functions.equals([true, true]), f"Should compare {type(true)} as True."
+
+        assert not functions.equals(
+            [true, false]
+        ), f"Should compare {type(true)} as False."
+
+
+def test_sub():
+    template_dict = {"Parameters": {"Foo": {"Value": "bar"}}}
+
+    template = Template(template_dict)
+
+    assert (
+        functions.sub(template, "Foo ${Foo}") == "Foo bar"
+    ), "Should subsuite a parameter."
+
+    result = functions.sub(template, "not ${!Test}")
+
+    assert result == "not ${Test}", "Should return a string literal."
+
+    add_metadata(template_dict, "us-east-1")
+
+    template = Template(template_dict)
+
+    result = functions.sub(template, "${AWS::Region} ${Foo} ${!BASH_VAR}")
+
+    assert result == "us-east-1 bar ${BASH_VAR}", "Should render multiple variables."

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -1,4 +1,7 @@
+from __future__ import with_statement
+
 import inspect
+from typing import Any, Dict
 
 import pytest
 
@@ -62,6 +65,357 @@ def test_cidr(fake_t: Template):
     assert "unable to convert" in str(e)
 
 
+@pytest.mark.xfail(reason="Not Implemented.")
+def test_and(fake_t):
+    functions.and_(fake_t, [])
+
+
+def test_equals(fake_t: Template):
+    # AWS is not very clear on what is valid here?
+    # > A value of any type that you want to compare.
+
+    with pytest.raises(TypeError):
+        functions.equals(fake_t, {})
+
+    with pytest.raises(ValueError):
+        functions.equals(fake_t, [0])
+
+    true_lst = [True, "foo", 5, ["test"], {"foo": "foo"}]
+    false_lst = [False, "bar", 10, ["bar"], {"bar": "bar"}]
+
+    for idx, true in enumerate(true_lst):
+        false = false_lst[idx]
+
+        assert functions.equals(
+            fake_t, [true, true]
+        ), f"Should compare {type(true)} as True."
+
+        assert not functions.equals(
+            fake_t, [true, false]
+        ), f"Should compare {type(true)} as False."
+
+
+def test_if(fake_t: Template):
+
+    template = {"Conditions": {"test": False}}
+
+    fake_t.template = template
+
+    with pytest.raises(TypeError) as e:
+        result = functions.if_(fake_t, {})
+
+    assert "must be a List, not dict." in str(e.value)
+
+    with pytest.raises(ValueError) as e:
+        result = functions.if_(fake_t, [0])
+
+    assert "The equation for !If or Fn::If must contain" in str(e.value)
+
+    with pytest.raises(TypeError) as e:
+        result = functions.if_(fake_t, [0, 0, 0])
+
+    assert "AWS Condition should be str, not int." in str(e.value)
+
+    result = functions.if_(fake_t, ["test", "true_value", "false_value"])
+
+    assert result == "false_value", "Should return the false value."
+
+    template["Conditions"]["test"] = True
+
+    result = functions.if_(fake_t, ["test", "true_value", "false_value"])
+
+    assert result == "true_value", "Should return the true value."
+
+    with pytest.raises(Exception):
+        # First value should the name of the condition to lookup
+        functions.if_(fake_t, [True, "True", "False"])
+
+
+@pytest.mark.xfail(reason="Not Implemented.")
+def test_not(fake_t):
+    functions.not_(fake_t, [])
+
+
+@pytest.mark.xfail(reason="Not Implemented.")
+def test_or(fake_t):
+    functions.or_(fake_t, [])
+
+
+def test_find_in_map():
+    template = {}
+
+    add_metadata(template, Template.Region)
+
+    template = Template(template)
+
+    with pytest.raises(TypeError) as e:
+        functions.find_in_map(template, {})
+
+    assert "must be a List, not dict." in str(e)
+
+    with pytest.raises(ValueError) as e:
+        functions.find_in_map(template, [0])
+
+    assert "a MapName, TopLevelKey and SecondLevelKey." in str(e)
+
+    map_name = "TestMap"
+    first_key = "FirstKey"
+    second_key = "SecondKey"
+
+    equation = [map_name, first_key, second_key]
+
+    with pytest.raises(KeyError) as e:
+        functions.find_in_map(template, equation)
+
+    assert "Unable to find Mappings section in template." in str(e)
+
+    template.template["Mappings"] = {}
+
+    with pytest.raises(KeyError) as e:
+        functions.find_in_map(template, equation)
+
+    assert f"Unable to find {map_name} in Mappings section of template." in str(e)
+
+    template.template["Mappings"][map_name] = {}
+
+    with pytest.raises(KeyError) as e:
+        functions.find_in_map(template, equation)
+
+    assert f"Unable to find key {first_key}" in str(e)
+
+    template.template["Mappings"][map_name][first_key] = {}
+
+    with pytest.raises(KeyError) as e:
+        functions.find_in_map(template, equation)
+
+    assert f"Unable to find key {second_key}" in str(e)
+
+    expected = "ExpectedValue"
+
+    template.template["Mappings"][map_name][first_key][second_key] = expected
+
+    result = functions.find_in_map(template, equation)
+
+    assert result == expected
+
+
+def test_get_att():
+
+    template = {"Resources": {}}
+
+    add_metadata(template, Template.Region)
+
+    template = Template(template)
+
+    with pytest.raises(TypeError) as e:
+        functions.get_att(template, {})
+
+    assert "Fn::GetAtt - The equation must be a List, not dict." in str(e)
+
+    with pytest.raises(ValueError) as e:
+        functions.get_att(template, [0])
+
+    assert "the logicalNameOfResource and attributeName." in str(e)
+
+    with pytest.raises(TypeError) as e:
+        functions.get_att(template, [0, 0])
+
+    assert "logicalNameOfResource and attributeName must be String." in str(e)
+
+    resource_name = "TestA"
+    att = "TestAttribute"
+
+    equation = [resource_name, att]
+
+    with pytest.raises(KeyError) as e:
+        functions.get_att(template, equation)
+
+    assert f"{resource_name} not found in template." in str(e)
+
+    template.template["Resources"]["TestA"] = {}
+
+    result = functions.get_att(template, equation)
+
+    assert result == f"{resource_name}.{att}"
+
+
+def test_get_az(fake_t: Template, mocker):
+
+    mock_fetch = mocker.patch.object(functions, "get_region_azs")
+    mock_fetch.return_value = ["us-east-1-az-1", "us-east-1-az-2"]
+
+    with pytest.raises(TypeError) as e:
+        result = functions.get_azs(fake_t, [])
+
+    assert "region must be a String, not list." in str(e)
+
+    region = "us-east-1"
+
+    result = functions.get_azs(fake_t, region)
+
+    for az in result:
+        assert region in az
+
+
+def test_get_region_azs(mocker):
+
+    region_name = "us-east-1"
+
+    mocker.patch.object(functions, "REGION_DATA", None)
+    mock_fetch = mocker.patch.object(functions, "_fetch_region_data")
+    mock_fetch.return_value = []
+
+    with pytest.raises(Exception) as e:
+        result = functions.get_region_azs(region_name)
+
+    mock_fetch.assert_called()
+    assert f"Unable to find region {region_name}." in str(e)
+
+    region_data = [
+        {"code": "us-east-1", "zones": ["us-east-1e", "us-east-1f"]},
+        {"code": "us-east-2", "zones": ["us-east-2a", "us-east-2c"]},
+    ]
+
+    mocker.resetall()
+
+    mocker.patch.object(functions, "REGION_DATA", region_data)
+
+    result = functions.get_region_azs(region_name)
+
+    mock_fetch.assert_not_called()
+
+    for az in result:
+        assert region_name in az
+
+
+def test_fetch_region_data(mocker):
+
+    mock_post = mocker.patch("cloud_radar.cf.unit.functions.requests.get")
+    mock_json = mocker.patch("cloud_radar.cf.unit.functions.json.loads")
+    mock_json.return_value = "TestData"
+
+    mock_r = mock_post.return_value
+
+    mock_r.status_code = 200
+
+    result = functions._fetch_region_data()
+
+    assert result == "TestData"
+
+    mock_r.raise_for_status.assert_not_called()
+
+    assert result == "TestData"
+
+    mock_r.status_code = 500
+
+    functions._fetch_region_data()
+
+    mock_r.raise_for_status.assert_called()
+
+
+def test_import_value():
+
+    name = "TestImport"
+    value = "TestValue"
+
+    imports = {}
+
+    template = Template({}, imports)
+
+    with pytest.raises(TypeError) as e:
+        result = functions.import_value(template, [])
+
+    assert "Export should be String, not list." in str(e)
+
+    with pytest.raises(ValueError) as e:
+        result = functions.import_value(template, name)
+
+    assert "No imports have been configued" in str(e)
+
+    imports["FakeTest"] = "Fake"
+
+    with pytest.raises(KeyError) as e:
+        result = functions.import_value(template, name)
+
+    assert f"{name} not found" in str(e)
+
+    imports[name] = value
+
+    result = functions.import_value(template, name)
+
+    assert result == value
+
+
+def test_join(fake_t: Template):
+
+    value = [":", ["a", "b", "c"]]
+
+    result = functions.join(fake_t, value)
+
+    assert result == "a:b:c"
+
+    value: Dict[str, Any] = {}
+
+    with pytest.raises(Exception) as e:
+        result = functions.join(fake_t, value)
+
+    assert "must be list not dict" in str(e.value)
+
+    value = ["a", "b", "c"]
+
+    with pytest.raises(Exception) as e:
+        result = functions.join(fake_t, value)
+
+    assert "must contain a delimiter and a list of items to join." in str(e.value)
+
+    value = [1, {}]
+
+    with pytest.raises(Exception) as e:
+        result = functions.join(fake_t, value)
+
+    assert (
+        "The first value for !Join or Fn::Join must be a String and the second a List."
+        in str(e.value)
+    )
+
+
+@pytest.mark.xfail(reason="Not Implemented.")
+def test_select(fake_t):
+    functions.select(fake_t, [])
+
+
+@pytest.mark.xfail(reason="Not Implemented.")
+def test_split(fake_t):
+    functions.split(fake_t, [])
+
+
+def test_sub():
+    template_dict = {"Parameters": {"Foo": {"Value": "bar"}}}
+
+    template = Template(template_dict)
+
+    assert (
+        functions.sub(template, "Foo ${Foo}") == "Foo bar"
+    ), "Should subsuite a parameter."
+
+    result = functions.sub(template, "not ${!Test}")
+
+    assert result == "not ${Test}", "Should return a string literal."
+
+    add_metadata(template_dict, "us-east-1")
+
+    template = Template(template_dict)
+
+    result = functions.sub(template, "${AWS::Region} ${Foo} ${!BASH_VAR}")
+
+    assert result == "us-east-1 bar ${BASH_VAR}", "Should render multiple variables."
+
+
+@pytest.mark.xfail(reason="Not Implemented.")
+def test_transform(fake_t):
+    functions.transform(fake_t, [])
+
+
 def test_ref():
 
     template = {"Parameters": {"foo": {"Value": "bar"}}}
@@ -94,98 +448,3 @@ def test_ref():
         functions.ref(template, fake)
 
     assert f"Unrecognized AWS Pseduo variable: '{fake}'." in str(e.value)
-
-
-def test_if(fake_t: Template):
-
-    template = {"Conditions": {"test": False}}
-
-    fake_t.template = template
-
-    result = functions.if_(fake_t, ["test", "true_value", "false_value"])
-
-    assert result == "false_value", "Should return the false value."
-
-    template["Conditions"]["test"] = True
-
-    result = functions.if_(fake_t, ["test", "true_value", "false_value"])
-
-    assert result == "true_value", "Should return the true value."
-
-    with pytest.raises(Exception):
-        # First value should the name of the condition to lookup
-        functions.if_(fake_t, [True, "True", "False"])
-
-
-def test_join(fake_t: Template):
-
-    value = [":", ["a", "b", "c"]]
-
-    result = functions.join(fake_t, value)
-
-    assert result == "a:b:c"
-
-    value = {}
-
-    with pytest.raises(Exception) as e:
-        result = functions.join(fake_t, value)
-
-    assert "must be list not dict" in str(e.value)
-
-    value = ["a", "b", "c"]
-
-    with pytest.raises(Exception) as e:
-        result = functions.join(fake_t, value)
-
-    assert "must contain a delimiter and a list of items to join." in str(e.value)
-
-    value = [1, {}]
-
-    with pytest.raises(Exception) as e:
-        result = functions.join(fake_t, value)
-
-    assert (
-        "The first value for !Join or Fn::Join must be a String and the second a List."
-        in str(e.value)
-    )
-
-
-def test_equals(fake_t: Template):
-    # AWS is not very clear on what is valid here?
-    # > A value of any type that you want to compare.
-
-    true_lst = [True, "foo", 5, ["test"], {"foo": "foo"}]
-    false_lst = [False, "bar", 10, ["bar"], {"bar": "bar"}]
-
-    for idx, true in enumerate(true_lst):
-        false = false_lst[idx]
-
-        assert functions.equals(
-            fake_t, [true, true]
-        ), f"Should compare {type(true)} as True."
-
-        assert not functions.equals(
-            fake_t, [true, false]
-        ), f"Should compare {type(true)} as False."
-
-
-def test_sub():
-    template_dict = {"Parameters": {"Foo": {"Value": "bar"}}}
-
-    template = Template(template_dict)
-
-    assert (
-        functions.sub(template, "Foo ${Foo}") == "Foo bar"
-    ), "Should subsuite a parameter."
-
-    result = functions.sub(template, "not ${!Test}")
-
-    assert result == "not ${Test}", "Should return a string literal."
-
-    add_metadata(template_dict, "us-east-1")
-
-    template = Template(template_dict)
-
-    result = functions.sub(template, "${AWS::Region} ${Foo} ${!BASH_VAR}")
-
-    assert result == "us-east-1 bar ${BASH_VAR}", "Should render multiple variables."

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -54,9 +54,42 @@ def test_if():
 
     assert result == "true_value", "Should return the true value."
 
-    with pytest.raises((Exception)):
+    with pytest.raises(Exception):
         # First value should the name of the condition to lookup
         functions.if_(template, [True, "True", "False"])
+
+
+def test_join():
+
+    value = [":", ["a", "b", "c"]]
+
+    result = functions.join(value)
+
+    assert result == "a:b:c"
+
+    value = {}
+
+    with pytest.raises(Exception) as e:
+        result = functions.join(value)
+
+    assert "must be list not dict" in str(e.value)
+
+    value = ["a", "b", "c"]
+
+    with pytest.raises(Exception) as e:
+        result = functions.join(value)
+
+    assert "must contain a delimiter and a list of items to join." in str(e.value)
+
+    value = [1, {}]
+
+    with pytest.raises(Exception) as e:
+        result = functions.join(value)
+
+    assert (
+        "The first value for !Join or Fn::Join must be a String and the second a List."
+        in str(e.value)
+    )
 
 
 def test_equals():

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -23,6 +23,40 @@ def test_base64():
     assert result == "VGVzdFN0cmluZw=="
 
 
+def test_cidr():
+
+    with pytest.raises(Exception) as e:
+        result = functions.cidr({})
+
+    assert "must be a List, not" in str(e)
+
+    with pytest.raises(Exception) as e:
+        result = functions.cidr([1])
+
+    assert "a ipBlock, the count of subnets and the cidrBits." in str(e)
+
+    value = ["192.168.0.0/24", 6, 5]
+
+    expected = [
+        "192.168.0.0/27",
+        "192.168.0.32/27",
+        "192.168.0.64/27",
+        "192.168.0.96/27",
+        "192.168.0.128/27",
+        "192.168.0.160/27",
+    ]
+
+    result = functions.cidr(value)
+
+    assert result == expected
+
+    value[1] = 9
+    with pytest.raises(Exception) as e:
+        result = functions.cidr(value)
+
+    assert "unable to convert" in str(e)
+
+
 def test_ref():
 
     template = {"Parameters": {"foo": {"Value": "bar"}}}

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -6,6 +6,23 @@ from cloud_radar.cf.unit import functions
 from cloud_radar.cf.unit._template import Template, add_metadata
 
 
+def test_base64():
+    value = 1
+
+    with pytest.raises(Exception) as e:
+        result = functions.base64(value)
+
+    assert "The value for !Base64 or Fn::Base64 must be a String, not int." in str(
+        e.value
+    )
+
+    value = "TestString"
+
+    result = functions.base64(value)
+
+    assert result == "VGVzdFN0cmluZw=="
+
+
 def test_ref():
 
     template = {"Parameters": {"foo": {"Value": "bar"}}}

--- a/tests/test_cf/test_unit/test_template.py
+++ b/tests/test_cf/test_unit/test_template.py
@@ -13,10 +13,20 @@ from cloud_radar.cf.unit._template import (
 def template():
     template_path = Path(__file__).parent / "../../templates/log_bucket/log_bucket.yaml"
 
-    return Template.from_yaml(template_path.resolve())
+    return Template.from_yaml(template_path.resolve(), {})
 
 
-def test_default(template: Template):
+def test_constructor(template: Template):
+
+    with pytest.raises(TypeError) as e:
+        Template("not a dict")  # type: ignore
+
+    assert "Template should be a dict, not str." in str(e)
+
+    with pytest.raises(TypeError) as e:
+        Template({}, "")  # type: ignore
+
+    assert "Imports should be a dict, not str." in str(e)
 
     assert isinstance(template.raw, str), "Should load a string instance of template"
     assert isinstance(
@@ -25,12 +35,6 @@ def test_default(template: Template):
     assert (
         template.Region == Template.Region
     ), "Should set the default region from the class."
-
-
-def test_missing_template():
-
-    with pytest.raises(TypeError):
-        Template("not a dict")
 
 
 @patch("builtins.open", new_callable=mock_open, read_data="{'Foo': 'bar'}")


### PR DESCRIPTION
Move Intrinsic functions to their own module and get most of [them](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) implemented.

Functions: 
1. [x] Fn::Base64
2. [x] Fn::Cidr
3. [x] Condition functions (This is like an entire new list) 🤔
    - [x] Fn::And
    - [x] Fn::Equals
    - [x] Fn::If
    - [x] Fn::Not
    - [x] Fn::Or
4. [x] Fn::FindInMap
5. [x] Fn::GetAtt
6. [x] Fn::GetAZs
7. [x] Fn::ImportValue
8. [x] Fn::Join
9. [x] Fn::Select
10. [x] Fn::Split
11. [x] Fn::Sub
12. [x] Fn::Transform
13. [x] Ref