### PR TITLE
Enforce restrictions when using nested Intrinsic and Conditional functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,6 @@ A real functional testing example using Pytest can be seen [here](./tests/test_c
 - Handle References to resources that shouldn't exist.
   * It's currently possible that a `!Ref` to a Resource stays in the final template even if that resource is later removed because of a conditional.
 - Handle function order
-  * Some functions restrict which functions can be nested in [them](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#w2ab1c33c28c21c45).
   * Some functions are only allowed in [certain parts](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html) of the template.
 
 ### Functional

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -712,8 +712,11 @@ def ref(template: "Template", var_name: str) -> Any:
 
     if var_name in template.template["Parameters"]:
         return template.template["Parameters"][var_name]["Value"]
-    else:
+
+    if var_name in template.template["Resources"]:
         return var_name
+
+    raise Exception(f"Fn::Ref - {var_name} is not a valid Resource or Parameter.")
 
 
 def get_region_azs(region_name: str) -> List[str]:
@@ -764,9 +767,11 @@ CONDITIONS: Dispatch = {
     "Fn::If": if_,
     "Fn::Not": not_,
     "Fn::Or": or_,
+    "Fn::Condition": condition,
 }
 
 INTRINSICS: Dispatch = {
+    "Fn::If": if_,  # Conditional function but is allowed here
     "Fn::Base64": base64,
     "Fn::Cidr": cidr,
     "Fn::FindInMap": find_in_map,
@@ -808,6 +813,7 @@ ALLOWED_FUNCTIONS: Dict[str, Dispatch] = {
     },
     "Fn::Not": ALLOWED_NESTED_CONDITIONS,
     "Fn::Or": ALLOWED_NESTED_CONDITIONS,
+    "Fn::Condition": {},  # Only allows strings
     "Fn::Base64": ALL_FUNCTIONS,
     "Fn::Cidr": {
         "Fn::Select": select,

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -617,7 +617,7 @@ def test_transform(fake_t):
 
 def test_ref():
 
-    template = {"Parameters": {"foo": {"Value": "bar"}}}
+    template = {"Parameters": {"foo": {"Value": "bar"}}, "Resources": {}}
 
     add_metadata(template, Template.Region)
 
@@ -635,11 +635,10 @@ def test_ref():
 
     assert result == "bar", "Should reference parameters."
 
-    result = functions.ref(template, "SomeResource")
+    with pytest.raises(Exception) as ex:
+        result = functions.ref(template, "SomeResource")
 
-    assert (
-        result == "SomeResource"
-    ), "If not a psedo var or parameter it should return the input."
+    assert "not a valid Resource" in str(ex)
 
     fake = "AWS::FakeVar"
 


### PR DESCRIPTION
Some functions restrict other functions from being nested inside of them. Before we didn't enforce those restrictions. This PR modifies the recursive resolve_values functions to use a passed-in dictionary to dispatch function calls. If a function is found but it not allowed then a Value error is thrown. 

In the future this should be refactored. it would be nice to know things like why is X not allowed. What is X nested in?