### PR TITLE
fix bug with nested conditions

### DIFF
--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -271,7 +271,14 @@ def condition(template: "Template", name: Any) -> bool:
             f"Fn::Condition - Unable to find condition '{name}' in template."
         )
 
-    return template.template["Conditions"][name]
+    condition_value = template.template["Conditions"][name]
+
+    if not isinstance(condition_value, bool):
+        condition_value: bool = template.resolve_values(  # type: ignore
+            condition_value, allowed_func=ALLOWED_NESTED_CONDITIONS
+        )
+
+    return condition_value
 
 
 def find_in_map(template: "Template", values: Any) -> Any:
@@ -771,7 +778,7 @@ CONDITIONS: Dispatch = {
     "Fn::If": if_,
     "Fn::Not": not_,
     "Fn::Or": or_,
-    "Fn::Condition": condition,
+    "Condition": condition,
 }
 
 INTRINSICS: Dispatch = {
@@ -817,7 +824,7 @@ ALLOWED_FUNCTIONS: Dict[str, Dispatch] = {
     },
     "Fn::Not": ALLOWED_NESTED_CONDITIONS,
     "Fn::Or": ALLOWED_NESTED_CONDITIONS,
-    "Fn::Condition": {},  # Only allows strings
+    "Condition": {},  # Only allows strings
     "Fn::Base64": ALL_FUNCTIONS,
     "Fn::Cidr": {
         "Fn::Select": select,

--- a/tests/templates/log_bucket/log_bucket.yaml
+++ b/tests/templates/log_bucket/log_bucket.yaml
@@ -19,6 +19,7 @@ Parameters:
 Conditions:
   RetainBucket: !Equals [ !Ref KeepBucket, "TRUE" ]
   DeleteBucket: !Equals [ !Ref KeepBucket, "FALSE" ]
+  AlwaysTrue: !Or [!Condition RetainBucket, !Condition DeleteBucket]
 
 Resources:
   LogsBucket:

--- a/tests/test_cf/test_examples/test_unit.py
+++ b/tests/test_cf/test_examples/test_unit.py
@@ -42,3 +42,6 @@ def test_log_retain(template):
     bucket_name = bucket["Properties"]["BucketName"]
 
     assert "us-west-2" in bucket_name
+
+    assert result["Conditions"]["AlwaysTrue"] is True
+    assert isinstance(bucket["Condition"], bool)


### PR DESCRIPTION
This fixes a bug where `Conditions` in the template worked but not the `!Condition` intrinsic function. It also likely fixed a edge case where it was possible that instead of getting the result of the condition you would have gotten the unresolved value (an intrinsic function).

This was the result of several issues.
1. I didn't know about the `!Condition` intrinsic function because of the strange way it's documented on a seprate page away from both regular intrinsic functions and the other conditional intrinsic functions.
2. For whatever reason the full name for `!Condition` is NOT `Fn::Condition` like all the other conditional/intrinsic functions. Instead its full name is `Condition`. This means it was not caught by the existing logic that solves these functions by their full name.

It was not fixed in a very elegant way but fixing it properly will take a very careful refactoring of how resolving values works.