### PR TITLE
Fix undocumented behavior in intrinsic functions

### DIFF
--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -164,7 +164,7 @@ class Template:
                     continue
 
                 if key not in allowed_func:
-                    raise ValueError(f"{key} not allowed here.")
+                    raise ValueError(f"{key} with value ({value}) not allowed here")
 
                 value = self.resolve_values(
                     value,

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -821,6 +821,7 @@ ALLOWED_FUNCTIONS: Dict[str, Dispatch] = {
         "Fn::Select": select,
         "Fn::Sub": sub,
         "Ref": ref,
+        "Fn::ImportValue": import_value,
     },
     "Fn::Not": ALLOWED_NESTED_CONDITIONS,
     "Fn::Or": ALLOWED_NESTED_CONDITIONS,
@@ -892,6 +893,7 @@ ALLOWED_FUNCTIONS: Dict[str, Dispatch] = {
         "Fn::Join": join,
         "Fn::Select": select,
         "Ref": ref,
+        "Fn::Sub": sub,
     },
     "Fn::Transform": {},  # Transform isn't fully implemented
     "Ref": {},  # String only.

--- a/tests/test_cf/test_unit/test_template.py
+++ b/tests/test_cf/test_unit/test_template.py
@@ -167,17 +167,17 @@ def test_function_order():
     with pytest.raises(ValueError) as ex:
         _ = template.resolve_values(test_if, functions.ALL_FUNCTIONS)
 
-    assert "Fn::If not allowed here." in str(ex)
+    assert "Fn::If with value" in str(ex)
 
     with pytest.raises(ValueError) as ex:
         _ = template.resolve_values({"Fn::Base64": ""}, functions.CONDITIONS)
 
-    assert "Fn::Base64 not allowed here." in str(ex)
+    assert "Fn::Base64 with value" in str(ex)
 
     with pytest.raises(ValueError) as ex:
         _ = template.resolve_values({"Fn::Not": ""}, functions.INTRINSICS)
 
-    assert "Fn::Not not allowed here." in str(ex)
+    assert "Fn::Not with value" in str(ex)
 
 
 def test_set_params():


### PR DESCRIPTION
The PR fixes some undocumented behavior where you can call other nested functions (aka "supported functions") from inside a condition/intrinsic function that was not listed by the AWS docs.

1. Allow `Fn::Sub to be called from inside `Fn::Sub`. ([AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html#w2ab1c31c28c64c13))
2. Allow `Fn::ImportValue` to be called from inside `Fn::If`. ([AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#w2ab1c31c28c21c29))