### PR TITLE
Add support for dynamic references

### DIFF
--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, Optional, Tuple, Union
 
@@ -27,7 +28,10 @@ class Template:
     URLSuffix: str = "amazonaws.com"  # Other regions not implemented
 
     def __init__(
-        self, template: Dict[str, Any], imports: Optional[Dict[str, str]] = None
+        self,
+        template: Dict[str, Any],
+        imports: Optional[Dict[str, str]] = None,
+        dynamic_references: Optional[Dict[str, Dict[str, str]]] = None,
     ) -> None:
         """Loads a Cloudformation template from a file and saves
         it as a dictionary.
@@ -36,14 +40,21 @@ class Template:
             template (Dict): The Cloudformation template as a dictionary.
             imports (Optional[Dict[str, str]], optional): Values this template plans
             to import from other stacks exports. Defaults to None.
+            dynamic_references (Optional[Dict[str, Dict[str, str]]], optional): Values
+            this template plans to dynamically lookup from ssm/secrets manager.
+            Defaults to None.
 
         Raises:
             TypeError: If template is not a dictionary.
             TypeError: If imports is not a dictionary.
+            TypeError: If dynamic_references is not a dictionary.
         """
 
         if imports is None:
             imports = {}
+
+        if dynamic_references is None:
+            dynamic_references = {}
 
         if not isinstance(template, dict):
             raise TypeError(
@@ -53,14 +64,23 @@ class Template:
         if not isinstance(imports, dict):
             raise TypeError(f"Imports should be a dict, not {type(imports).__name__}.")
 
+        if not isinstance(dynamic_references, dict):
+            raise TypeError(
+                f"Dynamic References should be a dict, not {type(dynamic_references).__name__}."
+            )
+
         self.raw: str = yaml.dump(template)
         self.template = template
         self.Region = Template.Region
         self.imports = imports
+        self.dynamic_references = dynamic_references
 
     @classmethod
     def from_yaml(
-        cls, template_path: Union[str, Path], imports: Optional[Dict[str, str]] = None
+        cls,
+        template_path: Union[str, Path],
+        imports: Optional[Dict[str, str]] = None,
+        dynamic_references: Optional[Dict[str, Dict[str, str]]] = None,
     ) -> Template:
         """Loads a Cloudformation template from file.
 
@@ -68,6 +88,9 @@ class Template:
             template_path (Union[str, Path]): The path to the template.
             imports (Optional[Dict[str, str]], optional): Values this template plans
             to import from other stacks exports. Defaults to None.
+            dynamic_references (Optional[Dict[str, Dict[str, str]]], optional): Values
+            this template plans to dynamically lookup from ssm/secrets manager.
+            Defaults to None.
 
         Returns:
             Template: A Template object ready for testing.
@@ -82,7 +105,7 @@ class Template:
 
         template = yaml.load(tmp_str, Loader=yaml.FullLoader)
 
-        return cls(template, imports)
+        return cls(template, imports, dynamic_references)
 
     def render(
         self, params: Optional[Dict[str, str]] = None, region: Optional[str] = None
@@ -250,8 +273,67 @@ class Template:
                 )
                 for item in data
             ]
+        elif isinstance(data, str):
+            return self.resolve_dynamic_references(data)
         else:
             return data
+
+    def resolve_dynamic_references(self, data: str) -> str:
+        """
+        Replaces any dynamic references in the provided data with values from
+        our configuration.
+
+        Args:
+            data (str): the value to replace dynamic references within
+
+        Raises:
+            ValueError: If a dynamic reference has been used and no dynamic
+            references have been configured.
+            KeyError: If a dynamic reference name has been used and is not
+            found in the configuration
+        """
+
+        if "{{resolve:" in data:
+            print("For str may need to resolve SSM parameters: %s", data)
+
+            matches = re.search(
+                "{{(resolve:(ssm|ssm-secure|secretsmanager):[a-zA-Z0-9_.\-/]+(:\d+)?)}}",
+                data,
+            )
+
+            if matches:
+                parts = matches.group(1).split(":", 3)
+                print(parts)
+
+                service = parts[1]
+                key = parts[2]
+
+                if service not in self.dynamic_references:
+                    raise KeyError(
+                        "Service %s not included in dynamic references configuration",
+                        service,
+                    )
+                if key not in self.dynamic_references[service]:
+                    raise KeyError(
+                        "Key %s not included in dynamic references configuration for service %s",
+                        key,
+                        service,
+                    )
+
+                updated_value = data.replace(
+                    f"{{resolve:{service}:{key}}}",
+                    self.dynamic_references[service][key],
+                )
+
+                # run the updated value through this function again to pick up any other references
+                return self.resolve_dynamic_references(updated_value)
+            else:
+                raise ValueError(
+                    "Found '{{resolve' in string, but did not match expected regex - %s",
+                    data,
+                )
+
+        return data
 
     def set_parameters(self, parameters: Union[Dict[str, str], None] = None) -> None:
         """Sets the parameters for a template using the provided parameters or

--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -303,16 +303,13 @@ class Template:
         if "{{resolve:" in data:
             print("For str may need to resolve SSM parameters: ", data)
 
-            # The allowed values for the service and key regex are taken
-            # from the documentation for this feature in
-            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-pattern
             matches = re.search(
-                "{{(resolve:(ssm|ssm-secure|secretsmanager):[a-zA-Z0-9_.\-/]+(:\d+)?)}}",
+                "{{(resolve:(ssm|ssm-secure|secretsmanager):[a-zA-Z0-9_.-/:]+)}}",
                 data,
             )
 
             if matches:
-                parts = matches.group(1).split(":", 3)
+                parts = matches.group(1).split(":", 2)
                 print(parts)
 
                 service = parts[1]
@@ -324,7 +321,10 @@ class Template:
                     )
                 if key not in self.dynamic_references[service]:
                     raise KeyError(
-                        f"Key {key} not included in dynamic references configuration for service {service}"
+                        (
+                            f"Key {key} not included in dynamic references "
+                            f"configuration for service {service}"
+                        )
                     )
 
                 print(f"{{{{resolve:{service}:{key}}}}}")
@@ -334,7 +334,8 @@ class Template:
                     self.dynamic_references[service][key],
                 )
 
-                # run the updated value through this function again to pick up any other references
+                # run the updated value through this function again
+                # to pick up any other references
                 return self.resolve_dynamic_references(updated_value)
             elif "${" not in data:
                 # If there is a "${" in the string it is likely we are meant to

--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -204,7 +204,7 @@ class Template:
 
         return stack
 
-    def resolve_values(
+    def resolve_values(  # noqa: max-complexity: 13
         self,
         data: Any,
         allowed_func: functions.Dispatch,
@@ -301,8 +301,6 @@ class Template:
         """
 
         if "{{resolve:" in data:
-            print("For str may need to resolve SSM parameters: ", data)
-
             matches = re.search(
                 "{{(resolve:(ssm|ssm-secure|secretsmanager):[a-zA-Z0-9_.-/:]+)}}",
                 data,
@@ -310,7 +308,6 @@ class Template:
 
             if matches:
                 parts = matches.group(1).split(":", 2)
-                print(parts)
 
                 service = parts[1]
                 key = parts[2]
@@ -327,8 +324,6 @@ class Template:
                         )
                     )
 
-                print(f"{{{{resolve:{service}:{key}}}}}")
-                print(self.dynamic_references[service][key])
                 updated_value = data.replace(
                     f"{{{{resolve:{service}:{key}}}}}",
                     self.dynamic_references[service][key],

--- a/tests/test_cf/test_unit/test_template.py
+++ b/tests/test_cf/test_unit/test_template.py
@@ -319,7 +319,7 @@ def test_resolve_dynamic_references():
         }
     }
 
-    template = Template(t)
+    template = Template(t, dynamic_references=dynamic_references)
 
     result = template.render()
 
@@ -328,5 +328,5 @@ def test_resolve_dynamic_references():
     assert foo_resource_props["PolicyName"] == "mgt-cld-rdr-launch-role-pol"
 
     # This item resolves the SSM parameter after a substitution has been performed
-    bar_resource_props = result["Resources"]["Foo"]["Properties"]
+    bar_resource_props = result["Resources"]["Bar"]["Properties"]
     assert bar_resource_props["PolicyName"] == "mgt-cld-55-rdr-launch-role-pol"

--- a/tests/test_cf/test_unit/test_template.py
+++ b/tests/test_cf/test_unit/test_template.py
@@ -298,14 +298,31 @@ def test_resolve_dynamic_references():
             "Foo": {
                 "Type": "AWS::IAM::Policy",
                 "Properties": {
-                    "PolicyName": "mgt-{{resolve:ssm:/account/current/short_name}}-launch-role-pol",
+                    "PolicyName": (
+                        "mgt-{{resolve:ssm:/account/current/short_name}}"
+                        "-launch-role-pol"
+                    ),
                 },
             },
             "Bar": {
                 "Type": "AWS::IAM::Policy",
                 "Properties": {
                     "PolicyName": {
-                        "Fn::Sub": "mgt-{{resolve:ssm:/account/${AWS::AccountId}/short_name}}-launch-role-pol"
+                        "Fn::Sub": (
+                            "mgt-{{resolve:ssm:/account/${AWS::AccountId}/short_name}}"
+                            "-launch-role-pol"
+                        )
+                    },
+                },
+            },
+            "TwoRefTest": {
+                "Type": "AWS::IAM::Policy",
+                "Properties": {
+                    "PolicyName": {
+                        "Fn::Sub": (
+                            "mgt-{{resolve:ssm:/account/${AWS::AccountId}/short_name}}"
+                            "-launch-{{resolve:ssm:/account/current/short_name}}-pol"
+                        )
                     },
                 },
             },
@@ -330,3 +347,106 @@ def test_resolve_dynamic_references():
     # This item resolves the SSM parameter after a substitution has been performed
     bar_resource_props = result["Resources"]["Bar"]["Properties"]
     assert bar_resource_props["PolicyName"] == "mgt-cld-55-rdr-launch-role-pol"
+
+    # This item contains multiple resolved parameters
+    two_resource_props = result["Resources"]["TwoRefTest"]["Properties"]
+    assert two_resource_props["PolicyName"] == "mgt-cld-55-rdr-launch-cld-rdr-pol"
+
+
+def test_resolve_all_types_dynamic_references():
+    # This contains one of each type of dynamic references, with
+    # the example resources coming from the documentation
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
+    t = {
+        "Resources": {
+            "MyRDSInstance": {
+                "Type": "AWS::RDS::DBInstance",
+                "Properties": {
+                    "DBName": "MyRDSInstance",
+                    "AllocatedStorage": "20",
+                    "DBInstanceClass": "db.t2.micro",
+                    "Engine": "mysql",
+                    "MasterUsername": (
+                        "{{resolve:secretsmanager:MyRDSSecret:SecretString:username}}"
+                    ),
+                    "MasterUserPassword": (
+                        "{{resolve:secretsmanager:MyRDSSecret:SecretString:password}}"
+                    ),
+                },
+            },
+            "MyIAMUser": {
+                "Type": "AWS::IAM::User",
+                "Properties": {
+                    "UserName": "MyUserName",
+                    "LoginProfile": {
+                        "Password": "{{resolve:ssm-secure:IAMUserPassword:10}}"
+                    },
+                },
+            },
+            "MyS3Bucket": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {"AccessControl": "{{resolve:ssm:S3AccessControl:2}}"},
+            },
+        }
+    }
+
+    dynamic_references = {
+        "ssm": {"S3AccessControl:2": "private"},
+        "ssm-secure": {"IAMUserPassword:10": "my-really-secure-iam-password"},
+        "secretsmanager": {
+            "MyRDSSecret:SecretString:username": "my-username",
+            "MyRDSSecret:SecretString:password": "my-password",
+        },
+    }
+
+    template = Template(t, dynamic_references=dynamic_references)
+    result = template.render()
+
+    rds_resource_props = result["Resources"]["MyRDSInstance"]["Properties"]
+    assert rds_resource_props["MasterUsername"] == "my-username"
+    assert rds_resource_props["MasterUserPassword"] == "my-password"
+
+    iam_resource_props = result["Resources"]["MyIAMUser"]["Properties"]
+    assert (
+        iam_resource_props["LoginProfile"]["Password"]
+        == "my-really-secure-iam-password"
+    )
+
+    s3_resource_props = result["Resources"]["MyS3Bucket"]["Properties"]
+    assert s3_resource_props["AccessControl"] == "private"
+
+
+def test_unknown_dynamic_references():
+    t = {
+        "Resources": {
+            "Foo": {
+                "Type": "AWS::IAM::Policy",
+                "Properties": {
+                    "PolicyName": (
+                        "mgt-{{resolve:ssm:/account/current/short_name}}"
+                        "-launch-role-pol"
+                    ),
+                },
+            },
+        },
+    }
+
+    # Case where there is no dynamic reference configuration
+    template = Template(t)
+    with pytest.raises(
+        KeyError, match="Service ssm not included in dynamic references configuration"
+    ):
+        template.render()
+
+    # Case where there is a dynamic reference configuration for the service,
+    # but not the key
+    template = Template(t, dynamic_references={"ssm": {"not/the/right/key": "dummy"}})
+    with pytest.raises(
+        KeyError,
+        match=(
+            "Key /account/current/short_name not"
+            " included in dynamic references configuration"
+            " for service ssm"
+        ),
+    ):
+        template.render()


### PR DESCRIPTION
See #220 for background. 

This is a draft & WIP. Just creating a PR just now to kind of show I've made a start on this (although it will be a few days till I get back to it). There are flake8 issues in this still. 

This currently works with the `PolicyName` example which includes a dynamic reference, and the case where the dynamic reference key contains a parameter which would be updated by an `Fn::Sub`. 

This is tackling it from the point of introducing a breaking change - once it _functionally_ works we can work out the best approach for breaking / non-breaking. It needs for tests for validation cases but I'll take a look at that in a few more days. 