### PR TITLE
Push release candidates to the real PyPi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,16 +83,7 @@ jobs:
       - name: Setup Poetry
         run: pip install poetry==1.4.2
 
-      - name: Publish to Test PyPI
-        if: github.base_ref == 'develop'
-        run: |
-          poetry version ${{needs.tag.outputs.tag}}
-          poetry build
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry publish -r testpypi --username '${{ secrets.PYPI_USERNAME }}' --password '${{ secrets.TEST_PYPI_PASSWORD }}'
-
       - name: Publish to PyPI
-        if: github.base_ref == 'master'
         run: |
           poetry version ${{needs.tag.outputs.tag}}
           poetry build


### PR DESCRIPTION
Recently pushes to test pypi started to fail because of some auth issue. It's probably a good idea to push to the real pypi anyway to make it easier for users to install the release candidates.