### PR TITLE
add codecov config file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 3%
+        base: auto
+       # advanced settings
+        branches:
+          - develop
+        if_ci_failed: error #success, failure, error, ignore
+    patch:
+      default:
+        # basic
+        target: auto
+        threshold: 3%
+        base: auto
+        # advanced
+        branches:
+          - develop
+        if_ci_failed: error #success, failure, error, ignore

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,9 +6,6 @@ coverage:
         target: auto
         threshold: 3%
         base: auto
-       # advanced settings
-        branches:
-          - develop
         if_ci_failed: error #success, failure, error, ignore
     patch:
       default:
@@ -16,7 +13,4 @@ coverage:
         target: auto
         threshold: 3%
         base: auto
-        # advanced
-        branches:
-          - develop
         if_ci_failed: error #success, failure, error, ignore


### PR DESCRIPTION
We have lots of PRs that are failing because the codecov patch status check is too strict. This will allow PRs to pass even if the code coverage drops slightly.