### PR TITLE
allow ssm dynamic references to not include a version

### DIFF
--- a/tests/test_cf/test_unit/test_template.py
+++ b/tests/test_cf/test_unit/test_template.py
@@ -4,10 +4,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from cloud_radar.cf.unit import functions
-from cloud_radar.cf.unit._template import (
-    Template,
-    add_metadata,
-)
+from cloud_radar.cf.unit._template import Template, add_metadata
 
 
 @pytest.fixture
@@ -579,6 +576,7 @@ def test_resolve_all_types_dynamic_references():
                     "MasterUserPassword": (
                         "{{resolve:secretsmanager:MyRDSSecret:SecretString:password}}"
                     ),
+                    "SnapshotIdentifier": "{{resolve:ssm:development-snapshot-arn}}",
                 },
             },
             "MyIAMUser": {
@@ -598,7 +596,7 @@ def test_resolve_all_types_dynamic_references():
     }
 
     dynamic_references = {
-        "ssm": {"S3AccessControl:2": "private"},
+        "ssm": {"S3AccessControl:2": "private", "development-snapshot-arn": "some_arn"},
         "ssm-secure": {"IAMUserPassword:10": "my-really-secure-iam-password"},
         "secretsmanager": {
             "MyRDSSecret:SecretString:username": "my-username",


### PR DESCRIPTION
I did not mean to refactor the entire function. I just didn't realize how many edge cases there were when handling dynamic references. I used chatGPT for the regex. It took many tries before it gave me a working one. When I asked it why it took so long for us to derive the correct answer, it replied with a very generic list of reasons of why it might have taken so long. The top of that list was miscommunication. I asked it if it thought we miscommunicated and surprisingly it was able to clearly articulate how we miscommunicated. I am both excited and afraid of what the next 10 years will bring.