### PR TITLE
fix rendering of resources with a condition but not Properties

### DIFF
--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -151,6 +151,12 @@ class Template:
                 continue
 
             for r_name, r_value in get_section_items(template, section):
+                if section == "Resources" and "Properties" not in r_value:
+                    # While the Properties key is technically optional,
+                    # our processing requires it to be there to distinguish
+                    # this as a Resource when we perform further rendering
+                    r_value["Properties"] = {}
+
                 if is_conditional(r_value):
                     condition_value = get_condition_value(
                         r_value["Condition"], template["Conditions"]

--- a/tests/templates/log_bucket/log_bucket.yaml
+++ b/tests/templates/log_bucket/log_bucket.yaml
@@ -38,6 +38,10 @@ Resources:
       BucketName:
         !Sub ${BucketPrefix}-logs-${AWS::Region}
 
+  DeadLetterQueue:
+    Condition: AlwaysTrue
+    Type: AWS::SQS::Queue
+
   # Used for testng
   TestBucket:
     Condition: AlwaysFalse


### PR DESCRIPTION
Their Condition key was not being resolved correctly which caused the value for the entire resource to be set as the value from the condition. This caused the program to crash when trying to render the template. Thank to @dhutchison for both reporting the bug and coming up with this simple but elegant fix. See #246 for more details.