### PR TITLE
Feat/ssm parameters unit test example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: check-yaml
-        exclude: ^tests/templates
+        exclude: ^(tests/templates|examples/unit)
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,12 @@ repos:
   - repo: local
     hooks:
 
+      - id: isort
+        name: isort
+        entry: poetry run isort
+        language: system
+        types: [python]
+
       - id: black
         name: black
         entry: poetry run black

--- a/.scripts/bump.py
+++ b/.scripts/bump.py
@@ -4,7 +4,6 @@ import sys
 from typing import Any, Dict
 
 import requests
-
 import semver
 
 repo: str = "cloud-radar"

--- a/examples/unit/conditions/README.md
+++ b/examples/unit/conditions/README.md
@@ -6,7 +6,7 @@ This example shows two main scenarios:
 * Conditional resources were created or not.
 
 
-It uses [this AWS Labs sample template](https://github.com/awslabs/aws-cloudformation-templates/blob/1de97eda75e3b876b8fcb0166d2d4c0691bdcdf5/aws/services/SQS/SQSStandardQueue.json), that includes a condition for if an SQS Queue should have a Dead Letter Queue configured for it or not. This uses a pretty simple condition that simply checks if a parameter value was set to `true`, but this can be as compicated as your template requires.
+It uses [this AWS Labs sample template](https://github.com/awslabs/aws-cloudformation-templates/blob/1de97eda75e3b876b8fcb0166d2d4c0691bdcdf5/aws/services/SQS/SQSStandardQueue.json), that includes a condition for if an SQS Queue should have a Dead Letter Queue configured for it or not. This uses a pretty simple condition that simply checks if a parameter value was set to `true`, but this can be as complicated as your template requires.
 
 ```json
     "Conditions": {
@@ -22,7 +22,7 @@ It uses [this AWS Labs sample template](https://github.com/awslabs/aws-cloudform
 ```
 
 
-The rendered stack includes a number of method for determining if your conditions worked as epected.
+The rendered stack includes a number of method for determining if your conditions worked as expected.
 
 These methods can be used to assert if named resources exist or not:
 ```python
@@ -68,7 +68,7 @@ A test case is able to check that when the DLQ was not created, that this redriv
     assert main_queue.get_property_value("RedrivePolicy") == ''
 ```
 
-Or inversly that it was set and referenced the correct target queue:
+Or inversely that it was set and referenced the correct target queue:
 ```python
     # When the second queue is being created, the SQSQueue should have a
     # redrive policy set referring to it

--- a/examples/unit/parameters/IAM_Users_Groups_and_Policies.yaml
+++ b/examples/unit/parameters/IAM_Users_Groups_and_Policies.yaml
@@ -1,0 +1,79 @@
+# Example file taken from
+# https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services/IAM/IAM_Users_Groups_and_Policies.yaml
+#
+# This has been modified to add an AllowedPattern to the Password parameter
+AWSTemplateFormatVersion: '2010-09-09'
+Metadata:
+  License: Apache-2.0
+Description: 'AWS CloudFormation Sample Template IAM_Users_Groups_and_Policies: Sample
+  template showing how to create IAM users, groups and policies. It creates a single
+  user that is a member of a users group and an admin group. The groups each have
+  different IAM policies associated with them. Note: This example also creates an
+  AWSAccessKeyId/AWSSecretKey pair associated with the new user. The example is somewhat
+  contrived since it creates all of the users and groups, typically you would be creating
+  policies, users and/or groups that contain references to existing users or groups
+  in your environment. Note that you will need to specify the CAPABILITY_IAM flag
+  when you create the stack to allow this template to execute. You can do this through
+  the AWS management console by clicking on the check box acknowledging that you understand
+  this template creates IAM resources or by specifying the CAPABILITY_IAM flag to
+  the cfn-create-stack command line tool or CreateStack API call.'
+Parameters:
+  Password:
+    NoEcho: 'true'
+    Type: String
+    Description: New account password
+    MinLength: '1'
+    MaxLength: '41'
+    ConstraintDescription: the password must be between 1 and 41 characters, alphanumeric
+    AllowedPattern: "^[a-zA-Z0-9]*$"
+Resources:
+  CFNUser:
+    Type: AWS::IAM::User
+    Properties:
+      LoginProfile:
+        Password: !Ref 'Password'
+  CFNUserGroup:
+    Type: AWS::IAM::Group
+  CFNAdminGroup:
+    Type: AWS::IAM::Group
+  Users:
+    Type: AWS::IAM::UserToGroupAddition
+    Properties:
+      GroupName: !Ref 'CFNUserGroup'
+      Users: [!Ref 'CFNUser']
+  Admins:
+    Type: AWS::IAM::UserToGroupAddition
+    Properties:
+      GroupName: !Ref 'CFNAdminGroup'
+      Users: [!Ref 'CFNUser']
+  CFNUserPolicies:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: CFNUsers
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action: ['cloudformation:Describe*', 'cloudformation:List*', 'cloudformation:Get*']
+          Resource: '*'
+      Groups: [!Ref 'CFNUserGroup']
+  CFNAdminPolicies:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: CFNAdmins
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action: cloudformation:*
+          Resource: '*'
+      Groups: [!Ref 'CFNAdminGroup']
+  CFNKeys:
+    Type: AWS::IAM::AccessKey
+    Properties:
+      UserName: !Ref 'CFNUser'
+Outputs:
+  AccessKey:
+    Value: !Ref 'CFNKeys'
+    Description: AWSAccessKeyId of new user
+  SecretKey:
+    Value: !GetAtt [CFNKeys, SecretAccessKey]
+    Description: AWSSecretAccessKey of new user

--- a/examples/unit/parameters/README.md
+++ b/examples/unit/parameters/README.md
@@ -10,7 +10,7 @@ This supports all the types of CloudFormation parameters:
 * [SSM Parameter Types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#aws-ssm-parameter-types)
 
 
-You can use this feature to validate that any parameter configuration files are valid, and also use assertions to confirm that invalid values would be rejected. Parameters can either be supplied as a `dict` of Key/Value pairs, or loaded from configuration files. At this point the [CodePipeline artifact](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/deploy/index.html#supported-json-syntax) and [CloudFormation CLI](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/create-stack.html) formats.
+You can use this feature to validate that any parameter configuration files are valid, and also use assertions to confirm that invalid values would be rejected. Parameters can either be supplied as a `dict` of Key/Value pairs, or loaded from configuration files. At this point the [CodePipeline artifact](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/deploy/index.html#supported-json-syntax) and [CloudFormation CLI](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/create-stack.html) formats can be loaded in from files.
 
 The complete set of files for this example are in the examples/unit/parameters directory here (TODO LINK).
 
@@ -25,7 +25,7 @@ Inline:
         })
 ```
 
-From configuration files:
+From configuration files (this example uses a path relative to the test case file):
 ```python
     config_path = Path(__file__).parent / "invalid_params_regex.cf.json"
 

--- a/examples/unit/parameters/README.md
+++ b/examples/unit/parameters/README.md
@@ -1,0 +1,97 @@
+
+# What does this example cover?
+
+One of the features that lead me to adopting Cloud Radar was it's support for rendering intrinsic functions in a CloudFormation template, based on supplied parameters. As part of this Cloud Radar can validate that mandatory parameters are provided, and that all parameters are valid based on any defined [constraints](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-properties).
+
+
+This supports all the types of CloudFormation parameters:
+* [String & Number](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-properties)
+* [AWS-specific](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#aws-specific-parameter-types)
+* [SSM Parameter Types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#aws-ssm-parameter-types)
+
+
+You can use this feature to validate that any parameter configuration files are valid, and also use assertions to confirm that invalid values would be rejected. Parameters can either be supplied as a `dict` of Key/Value pairs, or loaded from configuration files. At this point the [CodePipeline artifact](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/deploy/index.html#supported-json-syntax) and [CloudFormation CLI](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/create-stack.html) formats.
+
+The complete set of files for this example are in the examples/unit/parameters directory here (TODO LINK).
+
+# Supplying Parameters
+
+As noted above, parameter values can be supplied in a few different ways.
+
+Inline:
+```python
+        template.create_stack(params={
+            "MyBucket": "bad-ssm-path-$*£&@*"
+        })
+```
+
+From configuration files:
+```python
+    config_path = Path(__file__).parent / "invalid_params_regex.cf.json"
+
+    template.create_stack(parameters_file=config_path)
+```
+
+Examples of the two configuration formats are shown below.
+
+```json
+{
+    "Parameters": {
+        "Password": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXZY"
+    }
+}
+```
+
+```json
+[
+    {
+        "ParameterKey": "Password",
+        "ParameterValue": "Abhd%k*"
+    }
+]
+```
+
+
+## Validating Parameters
+
+A test that creates a stack with a set of parameters and does not raise a `ValueError` of any sort means the parameters have passed the validation constraints the template defined. You can then assert that properties in the "created" resources match expectations.
+
+```python
+def test_valid_params(template: Template):
+  config_path = Path(__file__).parent / "valid_params.json"
+
+  stack = template.create_stack(parameters_file=config_path)
+
+  # No error at this point means that validation rules have
+  # passed, go on to check the resource properties
+  user_resource = stack.get_resource("CFNUser")
+  login_profile_props = user_resource.get_property_value("LoginProfile")
+  assert login_profile_props["Password"] == "aSuperSecurePassword"
+```
+
+You can validate that a parameter fails validation with a specific error. When building this up, it is sometimes easier to assert that it just raises a `ValueError` then output the error message so that the test can be updated to ensure the expected validation error is being encountered instead of a different one.
+
+```python
+def test_invalid_params(template: Template):
+  config = load_config("invalid_params.json")
+
+  with pytest.raises(
+    ValueError,
+    match=(
+      "Value abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXZY is longer "
+      "than the maximum length for parameter Password"
+    ),
+  ):
+    template.create_stack(config["Parameters"])
+```
+
+## SSM Parameter Types
+
+As well as validating that the SSM parameter key supplied matches the pattern for what an SSM parameter key should look like, Cloud Radar will substitute in values through the same configuration approach used for Dynamic References.
+
+This requires that when you define your `Template` in your test case that you include values that should be returned when SSM keys are referenced.
+
+```python
+
+
+```

--- a/examples/unit/parameters/invalid_params_length.json
+++ b/examples/unit/parameters/invalid_params_length.json
@@ -1,0 +1,5 @@
+{
+    "Parameters": {
+        "Password": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXZY"
+    }
+}

--- a/examples/unit/parameters/invalid_params_regex.cf.json
+++ b/examples/unit/parameters/invalid_params_regex.cf.json
@@ -1,0 +1,6 @@
+[
+    {
+        "ParameterKey": "Password",
+        "ParameterValue": "Abhd%k*"
+    }
+]

--- a/examples/unit/parameters/invalid_password_parameters_regex.json
+++ b/examples/unit/parameters/invalid_password_parameters_regex.json
@@ -1,0 +1,6 @@
+[
+    {
+        "ParameterKey": "Password",
+        "ParameterValue": "Abhd%k*"
+    }
+]

--- a/examples/unit/parameters/ssm/SSM_Parameter_example.yaml
+++ b/examples/unit/parameters/ssm/SSM_Parameter_example.yaml
@@ -18,7 +18,9 @@ Resources:
     Properties:
       DatabaseName: !Ref MyDatabase  # Reference the MyDatabase SSM parameter
       TableInput:
-        Name: my_table
+        # This name includes a Dynamic Reference to show the different ways that an
+        # SSM value could be imported
+        Name: "{{resolve:ssm:/my_parameters/database/name}}_my_table"
         StorageDescriptor:
           Columns:
             - Name: column_1

--- a/examples/unit/parameters/ssm/SSM_Parameter_example.yaml
+++ b/examples/unit/parameters/ssm/SSM_Parameter_example.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description:  A simple example of a template with SSM parameters.
+Parameters:
+  MyBucket:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Description: The bucket name where all the data will be put into.
+    Default: /my_parameters/bucket/name
+
+  MyDatabase:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Description: The name of the database where the table will be created.
+    Default: /my_parameters/database/name
+
+Resources:
+  MyTable:
+    Type: 'AWS::Glue::Table'
+    Properties:
+      DatabaseName: !Ref MyDatabase  # Reference the MyDatabase SSM parameter
+      TableInput:
+        Name: my_table
+        StorageDescriptor:
+          Columns:
+            - Name: column_1
+              Type: string
+          Location: !Sub 's3://${MyBucket}/test'  # Reference the MyBucket SSM parameter

--- a/examples/unit/parameters/ssm/test_ssm_parameters.py
+++ b/examples/unit/parameters/ssm/test_ssm_parameters.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cloud_radar.cf.unit import Template
+
+
+@pytest.fixture
+def template():
+    # This template contains a single parameter for "Password", which
+    # is constrained to be a string with a minimum length of 1 character,
+    # and a maximum of 41 characters.
+    #
+    # In this example we will use this to show a few ways to check that parameter
+    # validation works as expected and different ways to perform assertions.
+    #
+    # This example also uses CodePipeline like CloudFormation parameter files
+    # to show how you can validate this type of parameter file as part of
+    # your unit tests.
+    template_path = Path(__file__).parent / "SSM_Parameter_example.yaml"
+
+    return Template.from_yaml(template_path.resolve(), {})
+
+
+def test_default_values(template: Template):
+    # The template used in this example includes default values, this will show
+    # that these are valid, and that values can be substituted in.
+
+    stack = template.create_stack()
+
+    # No error at this point means that validation rules have
+    # passed, go on to check the resource properties to see the value
+    # has been substituted
+    table_resource = stack.get_resource("MyTable")
+
+    # Assert that the SSM parameter is resolved based on our dynamic reference
+    # lookup.
+    database_name_value = table_resource.get_property_value("DatabaseName")
+
+    assert database_name_value == "my-test-database"
+
+
+def test_invalid_ssm_pattern(template: Template):
+    with pytest.raises(
+        ValueError,
+        match=r"Value .* does not match the expected pattern for SSM parameter MyBucket",
+    ):
+        template.create_stack(params={"MyBucket": "bad-ssm-path-$*£&@*"})
+
+
+def test_ssm_key_without_reference():
+    print("TODO")
+
+
+def test_unsupported_ssm_parameter_type():
+    print("TODO")

--- a/examples/unit/parameters/test_parameters.py
+++ b/examples/unit/parameters/test_parameters.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cloud_radar.cf.unit import Template
+
+
+@pytest.fixture
+def template():
+    # This template contains a single parameter for "Password", which
+    # is constrained to be a string with a minimum length of 1 character,
+    # and a maximum of 41 characters.
+    #
+    # In this example we will use this to show a few ways to check that parameter
+    # validation works as expected and different ways to perform assertions.
+    #
+    # This example also uses CodePipeline like CloudFormation parameter files
+    # to show how you can validate this type of parameter file as part of
+    # your unit tests.
+    template_path = Path(__file__).parent / "IAM_Users_Groups_and_Policies.yaml"
+
+    return Template.from_yaml(template_path.resolve(), {})
+
+
+def test_valid_params(template: Template):
+    """
+    This test case loads a CodePipeline style configuration file
+    with a parameter value which meets all the validation criteria.
+
+    This should create the stack successfully and we should be able to
+    inspect the properties of the resource to see the parameter value
+    has been applied successfully.
+    """
+    config_path = Path(__file__).parent / "valid_params.json"
+
+    stack = template.create_stack(parameters_file=config_path)
+
+    # No error at this point means that validation rules have
+    # passed, go on to check the resource properties
+    user_resource = stack.get_resource("CFNUser")
+    login_profile_props = user_resource.get_property_value("LoginProfile")
+    assert login_profile_props["Password"] == "aSuperSecurePassword"
+
+
+def test_invalid_params_length(template: Template):
+    config_path = Path(__file__).parent / "invalid_params_length.json"
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Value abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXZY is longer "
+            "than the maximum length for parameter Password"
+        ),
+    ):
+        template.create_stack(parameters_file=config_path)
+
+
+def test_invalid_params_regex(template: Template):
+    # This example uses the CloudFormation like CLI
+    # configuration format
+    # https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/deploy/index.html#supported-json-syntax
+    #
+    # This is one of the formats that we can load as part of rendering a stack.
+    config_path = Path(__file__).parent / "invalid_params_regex.cf.json"
+
+    # Validate that the input we expect not to match our AllowedPattern constraint
+    # results in the expected error.
+    # Note that if special characters are going to appear in the expected error message
+    # you may need to escape them in the `match` value.
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Value Abhd%k\* does not match the AllowedPattern for parameter Password"
+        ),
+    ):
+        template.create_stack(parameters_file=config_path)

--- a/examples/unit/parameters/test_parameters.py
+++ b/examples/unit/parameters/test_parameters.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 import pytest
@@ -71,7 +70,7 @@ def test_invalid_params_regex(template: Template):
     with pytest.raises(
         ValueError,
         match=(
-            "Value Abhd%k\* does not match the AllowedPattern for parameter Password"
+            r"Value Abhd%k\* does not match the AllowedPattern for parameter Password"
         ),
     ):
         template.create_stack(parameters_file=config_path)

--- a/examples/unit/parameters/valid_params.json
+++ b/examples/unit/parameters/valid_params.json
@@ -1,0 +1,5 @@
+{
+    "Parameters": {
+        "Password": "aSuperSecurePassword"
+    }
+}

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,6 @@ import tempfile
 
 import nox
 
-
 nox.options.sessions = "lint", "mypy", "tests"
 
 locations = "src", "tests", "noxfile.py"

--- a/poetry.lock
+++ b/poetry.lock
@@ -433,19 +433,21 @@ flake8 = ">=6.0.0"
 dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit", "pytest", "tox"]
 
 [[package]]
-name = "flake8-import-order"
-version = "0.18.2"
-description = "Flake8 and pylama plugin that checks the ordering of import statements."
+name = "flake8-isort"
+version = "6.1.0"
+description = "flake8 plugin that integrates isort ."
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 files = [
-    {file = "flake8-import-order-0.18.2.tar.gz", hash = "sha256:e23941f892da3e0c09d711babbb0c73bc735242e9b216b726616758a920d900e"},
-    {file = "flake8_import_order-0.18.2-py2.py3-none-any.whl", hash = "sha256:82ed59f1083b629b030ee9d3928d9e06b6213eb196fe745b3a7d4af2168130df"},
+    {file = "flake8-isort-6.1.0.tar.gz", hash = "sha256:d4639343bac540194c59fb1618ac2c285b3e27609f353bef6f50904d40c1643e"},
 ]
 
 [package.dependencies]
-pycodestyle = "*"
-setuptools = "*"
+flake8 = "*"
+isort = ">=5.0.0,<6"
+
+[package.extras]
+test = ["pytest"]
 
 [[package]]
 name = "idna"
@@ -1002,40 +1004,61 @@ files = [
 
 [[package]]
 name = "pyyaml"
-version = "5.4.1"
+version = "6.0.1"
 description = "YAML parser and emitter for Python"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.6"
 files = [
-    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
-    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
-    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
-    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
-    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
-    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
-    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
-    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
-    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
-    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
-    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
+    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
+    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
 ]
 
 [[package]]
@@ -1055,20 +1078,20 @@ six = "*"
 
 [[package]]
 name = "requests"
-version = "2.28.1"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7, <4"
+python-versions = ">=3.7"
 files = [
-    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
-    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<3"
+charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<1.27"
+urllib3 = ">=1.21.1,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
@@ -1149,12 +1172,12 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "taskcat"
-version = "0.9.40"
+version = "0.9.41"
 description = "An OpenSource Cloudformation Deployment Framework"
 optional = false
 python-versions = "*"
 files = [
-    {file = "taskcat-0.9.40.tar.gz", hash = "sha256:7c9ee5db5c6743f04fe2d8303259c50db3cf02e07b8bd7952a80f0d493b2f509"},
+    {file = "taskcat-0.9.41.tar.gz", hash = "sha256:c45109158c418271d00d19811d2d19730acdc0075faf224e0458beea2c360d27"},
 ]
 
 [package.dependencies]
@@ -1169,11 +1192,12 @@ jsonschema = ">=3.0,<4.0"
 markupsafe = "2.0.1"
 pathspec = "0.10.3"
 pip = "*"
-PyYAML = ">=5.1,<6.0"
+PyYAML = ">=6.0,<7.0"
 reprint = "*"
-requests = ">2.17.0"
+requests = ">=2.31.0"
 setuptools = ">=40.4.3"
 tabulate = ">=0.8.2,<1.0"
+urllib3 = "<2"
 yattag = ">=1.10.0,<2.0"
 
 [[package]]
@@ -1279,4 +1303,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "2f766a30c6c4ae9dc028c5b29832db77a94509c1d126c2c6544d82444debe372"
+content-hash = "8eac16eae8569cedf37585f99b3ab7e64e47c871ea49d4c652e7e692b2e40278"

--- a/poetry.lock
+++ b/poetry.lock
@@ -470,6 +470,23 @@ files = [
 ]
 
 [[package]]
+name = "isort"
+version = "5.12.0"
+description = "A Python utility / library to sort Python imports."
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
+]
+
+[package.extras]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
@@ -1262,4 +1279,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "e5cd21192518260a126dd4ae423557c13ef9e6238b3e29124e7619ecaee43c5a"
+content-hash = "2f766a30c6c4ae9dc028c5b29832db77a94509c1d126c2c6544d82444debe372"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pytest = "^7.0.0"
 coverage = {extras = ["toml"], version = "^7.0.0"}
 pytest-cov = "^4.0.0"
 pytest-mock = "^3.6.1"
+isort = "^5.12.0"
 black = "^23.0.0"
 flake8 = "^6.0.0"
 flake8-black = "^0.3.0"
@@ -47,6 +48,9 @@ source = ["cloud_radar"]
 [tool.coverage.report]
 show_missing = true
 fail_under = 95
+
+[tool.isort]
+profile = "black"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-taskcat = "^0.9.20"
-cfn-flip = "^1.2.3"
+taskcat = "^0.9.41"
+cfn-flip = "^1.3.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"
@@ -32,7 +32,7 @@ isort = "^5.12.0"
 black = "^23.0.0"
 flake8 = "^6.0.0"
 flake8-black = "^0.3.0"
-flake8-import-order = "^0.18.1"
+flake8-isort = "^6.1.0"
 flake8-bugbear = "^23.0.0"
 mypy = "^1.0.0"
 types-requests = "^2.28.11"

--- a/src/cloud_radar/cf/e2e/__init__.py
+++ b/src/cloud_radar/cf/e2e/__init__.py
@@ -1,4 +1,3 @@
 from ._stack import Stack
 
-
 __all__ = ["Stack"]

--- a/src/cloud_radar/cf/e2e/_stack.py
+++ b/src/cloud_radar/cf/e2e/_stack.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Union
 
 from taskcat.testing import CFNTest
 
-
 Template = Union[str, Path]
 Parameters = Optional[Dict[str, Any]]
 Regions = Optional[List[str]]

--- a/src/cloud_radar/cf/unit/__init__.py
+++ b/src/cloud_radar/cf/unit/__init__.py
@@ -1,4 +1,3 @@
 from ._template import Template
 
-
 __all__ = ["Template"]

--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -462,33 +462,11 @@ class Template:
             raise ValueError("You passed a Parameter that was not in the Template.")
 
         for p_name, p_value in t_params.items():
-            # TODO: Need to add something in here for if the parameter type
-            # is one of the SSM ones, so that it can call
-            # self.dynamic_references["ssm"][key] to get the value
-            #
-            # TODO: also need to validate that the key actually exists to
-            # provide a helpful error message instance of just a KeyError
-
-            #
-            #
-
-            # if key not in self.dynamic_references[service]:
-            #   raise KeyError(
-            #       (
-            #           f"Key {key} not included in dynamic references "
-            #           f"configuration for service {service}"
-            #       )
-            #   )
-
             if p_name in parameters:
                 validate_parameter_constraints(
                     p_name, t_params[p_name], parameters[p_name]
                 )
 
-                # So roughly, this line needs to look at the type,
-                # OR DOES IT
-                # Should processing of t_params consider dynamic reference resolution?
-                # Then that would handle the defaults too
                 t_params[p_name]["Value"] = parameters[p_name]
                 continue
 
@@ -647,7 +625,6 @@ def validate_aws_parameter_constraints(
             "AWS::Route53::HostedZone::Id": "^[A-Z0-9]{,32}$",
             # All the docs say for this type is up to 255 ascii characters
             "AWS::EC2::KeyPair::KeyName": "^[ -~]{1,255}$",
-            # TODO: Validate this elsewhere too, common regex?
             "AWS::SSM::Parameter::Name": ssm_parameter_value_regex,
         }
         param_regex = parameter_type_regexes.get(parameter_type)

--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, Optional, Tuple, Union
 
+import json
 import yaml  # noqa: I100
 from cfn_tools import dump_yaml, load_yaml  # type: ignore  # noqa: I100, I201
 
@@ -108,15 +109,20 @@ class Template:
         return cls(template, imports, dynamic_references)
 
     def render(
-        self, params: Optional[Dict[str, str]] = None, region: Optional[str] = None
+        self,
+        params: Optional[Dict[str, str]] = None,
+        region: Optional[str] = None,
+        parameters_file: Optional[str] = None,
     ) -> dict:
         """Solves all conditionals, references and pseudo variables using
         the passed in parameters. After rendering the template all resources
-        that wouldn't get deployed because of a condtion statement are removed.
+        that wouldn't get deployed because of a condition statement are removed.
 
         Args:
             params (dict, optional): Parameter names and values to be used when rendering.
             region (str, optional): The region is used for the AWS::Region pseudo variable. Defaults to "us-east-1".
+            parameters_file (str, optional): Path to a parameters file to load. If this is supplied as well as params,
+                                    anything in params will take precedence.
 
         Returns:
             dict: The rendered template.
@@ -124,6 +130,15 @@ class Template:
 
         if region:
             self.Region = region
+
+        if parameters_file:
+            # Attempt to load params from a file.
+            loaded_params = self.load_params(parameters_file)
+            # If a file and a parameter dict were supplied, the parameter dict will take precedence.
+            if params:
+                loaded_params.update(params)
+
+            params = loaded_params
 
         self.template = yaml.load(self.raw, Loader=yaml.FullLoader)
         self.set_parameters(params)
@@ -135,6 +150,50 @@ class Template:
         self.template = self.remove_condtional_resources(self.template)
 
         return self.template
+
+    def load_params(self, parameter_file_path) -> Dict[str, Any]:
+        # There are ??? main formats for configuration files which are used by different AWS tools.
+        # All of these are JSON based, but are formatted differently internally.
+        # We want to look for hints and get out a common format.
+
+        with parameter_file_path.open() as f:
+            json_content = json.load(f)
+
+            if "Parameters" in json_content:
+                # This is a CodePipeline CloudFormation artifact format file
+                # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-cfn-artifacts.html#w4ab1c21c15c15
+                return json_content["Parameters"]
+
+            if type(json_content) == list and "ParameterKey" in json_content[0]:
+                # This file looks like the type of parameters that the CloudFormation
+                # CLI supports
+                # https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/create-stack.html
+
+                # Takes something in the format:
+                #     [
+                #         {
+                #             "ParameterKey": "Key1",
+                #             "ParameterValue": "Value1"
+                #         },
+                #         {
+                #             "ParameterKey": "Key2",
+                #             "ParameterValue": "Value2"
+                #         }
+                #     ]
+                #
+                #     And turns it in to:
+                #     {
+                #         "Key1": "Value1",
+                #         "Key2": "Value2
+                #     }
+                params = {}
+                for param in json_content:
+                    params[param["ParameterKey"]] = param["ParameterValue"]
+
+                return params
+
+            # If we get this far then we do not support this type of configuration file
+            raise ValueError("Parameter file is not in a supported format")
 
     def render_all_sections(self, template: Dict[str, Any]) -> Dict[str, Any]:
         """Solves all conditionals, references and pseudo variables for all sections"""
@@ -199,12 +258,15 @@ class Template:
         return template
 
     def create_stack(
-        self, params: Optional[Dict[str, str]] = None, region: Optional[str] = None
+        self,
+        params: Optional[Dict[str, str]] = None,
+        region: Optional[str] = None,
+        parameters_file: Optional[str] = None,
     ):
         if region:
             self.Region = region
 
-        self.render(params)
+        self.render(params, parameters_file=parameters_file)
 
         stack = Stack(self.template)
 
@@ -379,6 +441,21 @@ class Template:
             raise ValueError("You passed a Parameter that was not in the Template.")
 
         for p_name, p_value in t_params.items():
+            # TODO: Need to add something in here for if the parameter type
+            # is one of the SSM ones, so that it can call
+            # self.dynamic_references["ssm"][key] to get the value
+            #
+            # TODO: also need to validate that the key actually exists to
+            # provide a helpful error message instance of just a KeyError
+
+            # if key not in self.dynamic_references[service]:
+            #   raise KeyError(
+            #       (
+            #           f"Key {key} not included in dynamic references "
+            #           f"configuration for service {service}"
+            #       )
+            #   )
+
             if p_name in parameters:
                 validate_parameter_constraints(
                     p_name, t_params[p_name], parameters[p_name]
@@ -441,12 +518,12 @@ def validate_parameter_constraints(
 
         # Iterate over each item and call this method again with an
         # updated definition for the non-list type
-        updated_defintion = parameter_definition.copy()
-        updated_defintion["Type"] = trimmed_type
+        updated_definition = parameter_definition.copy()
+        updated_definition["Type"] = trimmed_type
 
         for part in parameter_value.split(","):
             validate_parameter_constraints(
-                parameter_name, updated_defintion, part.strip()
+                parameter_name, updated_definition, part.strip()
             )
 
 
@@ -466,43 +543,97 @@ def validate_aws_parameter_constraints(
         parameter_value (str): The supplied parameter value being validated
     """
 
-    parameter_type_regexes = {
-        # Reference for this was
-        # https://gist.github.com/rams3sh/4858d5150acba5383dd697fda54dda2c
-        "AWS::EC2::AvailabilityZone::Name": (
-            "^(af|ap|ca|eu|me|sa|us)-(central|north|(north(?:east|west))|"
-            "south|south(?:east|west)|east|west)-[0-9]+[a-z]{1}$"
-        ),
-        # Reference for the next few are
-        # https://blog.skeddly.com/2016/01/long-ec2-instance-ids-are-fully-supported.html
-        "AWS::EC2::Image::Id": "^ami-[a-f0-9]{8}([a-f0-9]{9})?$",
-        "AWS::EC2::Instance::Id": "^i-[a-f0-9]{8}([a-f0-9]{9})?$",
-        "AWS::EC2::SecurityGroup::Id": "^sg-[a-f0-9]{8}([a-f0-9]{9})?$",
-        "AWS::EC2::Subnet::Id": "^subnet-[a-f0-9]{8}([a-f0-9]{9})?$",
-        "AWS::EC2::VPC::Id": "^vpc-[a-f0-9]{8}([a-f0-9]{9})?$",
-        "AWS::EC2::Volume::Id": "^vol-[a-f0-9]{8}([a-f0-9]{9})?$",
-        # Reference for this was
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#cfn-ec2-securitygroup-groupname
-        "AWS::EC2::SecurityGroup::GroupName": r"^[a-zA-Z0-9 ._\-:\/()#,@\[\]+=&;{}!$*]{1,255}$",
-        # Bit of a guess this one, not sure what the minimum bound should be
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-hostedzoneid
-        "AWS::Route53::HostedZone::Id": "^[A-Z0-9]{,32}$",
-        # All the docs say for this type is up to 255 ascii characters
-        "AWS::EC2::KeyPair::KeyName": "^[ -~]{1,255}$",
-    }
-    param_regex = parameter_type_regexes.get(parameter_type)
+    # There are a few variants of SSM parameters, but they all have the
+    # same regex pattern
+    ssm_parameter_value_regex = r"^(/{0,1}(?!/))[A-Za-z0-9/-_]+(.([a-zA-Z]+))?$"
 
-    if param_regex is None:
-        # If a regex is defined, we know the regex to validate the parameter
-        raise KeyError(f"Unsupported parameter type {parameter_type}")
+    if parameter_type.startswith("AWS::SSM::Parameter::Value<"):
+        # TODO validate that the value in the angle brackets is a supported one
 
-    if not re.match(param_regex, parameter_value):
-        raise ValueError(
-            (
-                f"Value {parameter_value} does not match the expected pattern "
-                f"for parameter {parameter_name} and type {parameter_type}"
+        supported_ssm_value_types = [
+            "String",
+            "List<String>",
+            "CommaDelimitedList",
+            "AWS::EC2::AvailabilityZone::Name",
+            "AWS::EC2::Image::Id",
+            "AWS::EC2::Instance::Id",
+            "AWS::EC2::SecurityGroup::Id",
+            "AWS::EC2::Subnet::Id",
+            "AWS::EC2::VPC::Id",
+            "AWS::EC2::Volume::Id",
+            "AWS::EC2::SecurityGroup::GroupName",
+            "AWS::Route53::HostedZone::Id"
+            "AWS::EC2::KeyPair::KeyName"
+            "List<AWS::EC2::AvailabilityZone::Name>",
+            "List<AWS::EC2::Image::Id>",
+            "List<AWS::EC2::Instance::Id>",
+            "List<AWS::EC2::SecurityGroup::Id>",
+            "List<AWS::EC2::Subnet::Id>",
+            "List<AWS::EC2::VPC::Id>",
+            "List<AWS::EC2::Volume::Id>",
+            "List<AWS::EC2::SecurityGroup::GroupName>",
+            "List<AWS::Route53::HostedZone::Id>" "List<AWS::EC2::KeyPair::KeyName>",
+        ]
+
+        value_type = parameter_type[27:-1]
+        if value_type not in supported_ssm_value_types:
+            raise ValueError(
+                (
+                    f"Type {value_type} is not a supported SSM value type for "
+                    f" SSM parameter {parameter_name}"
+                )
             )
-        )
+
+        if not re.match(ssm_parameter_value_regex, parameter_value):
+            raise ValueError(
+                (
+                    f"Value {parameter_value} does not match the expected pattern "
+                    f"for SSM parameter {parameter_name}"
+                )
+            )
+
+    else:
+        # Other AWS parameter types
+
+        parameter_type_regexes = {
+            # Reference for this was
+            # https://gist.github.com/rams3sh/4858d5150acba5383dd697fda54dda2c
+            "AWS::EC2::AvailabilityZone::Name": (
+                "^(af|ap|ca|eu|me|sa|us)-(central|north|(north(?:east|west))|"
+                "south|south(?:east|west)|east|west)-[0-9]+[a-z]{1}$"
+            ),
+            # Reference for the next few are
+            # https://blog.skeddly.com/2016/01/long-ec2-instance-ids-are-fully-supported.html
+            "AWS::EC2::Image::Id": "^ami-[a-f0-9]{8}([a-f0-9]{9})?$",
+            "AWS::EC2::Instance::Id": "^i-[a-f0-9]{8}([a-f0-9]{9})?$",
+            "AWS::EC2::SecurityGroup::Id": "^sg-[a-f0-9]{8}([a-f0-9]{9})?$",
+            "AWS::EC2::Subnet::Id": "^subnet-[a-f0-9]{8}([a-f0-9]{9})?$",
+            "AWS::EC2::VPC::Id": "^vpc-[a-f0-9]{8}([a-f0-9]{9})?$",
+            "AWS::EC2::Volume::Id": "^vol-[a-f0-9]{8}([a-f0-9]{9})?$",
+            # Reference for this was
+            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#cfn-ec2-securitygroup-groupname
+            "AWS::EC2::SecurityGroup::GroupName": r"^[a-zA-Z0-9 ._\-:\/()#,@\[\]+=&;{}!$*]{1,255}$",
+            # Bit of a guess this one, not sure what the minimum bound should be
+            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html#cfn-route53-recordset-hostedzoneid
+            "AWS::Route53::HostedZone::Id": "^[A-Z0-9]{,32}$",
+            # All the docs say for this type is up to 255 ascii characters
+            "AWS::EC2::KeyPair::KeyName": "^[ -~]{1,255}$",
+            # TODO: Validate this elsewhere too, common regex?
+            "AWS::SSM::Parameter::Name": ssm_parameter_value_regex,
+        }
+        param_regex = parameter_type_regexes.get(parameter_type)
+
+        if param_regex is None:
+            # If a regex is defined, we know the regex to validate the parameter
+            raise KeyError(f"Unsupported parameter type {parameter_type}")
+
+        if not re.match(param_regex, parameter_value):
+            raise ValueError(
+                (
+                    f"Value {parameter_value} does not match the expected pattern "
+                    f"for parameter {parameter_name} and type {parameter_type}"
+                )
+            )
 
 
 def validate_number_parameter_constraints(

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -764,11 +764,6 @@ def ref(template: "Template", var_name: str) -> Any:
                 )
 
             # If we get this far, regular parameter value to lookup & return
-            # TODO: doing it here feels like it will mean we need the logic in
-            # multiple places, and that we wouldn't be able to validate the values
-            # in the resolved value against the AWS types (would we want to do that though,
-            # sounds like a step too far in reality)
-
             return template.template["Parameters"][var_name]["Value"]
 
     if var_name in template.template["Resources"]:

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -8,9 +8,7 @@ import base64 as b64
 import ipaddress
 import json
 import re
-
-# Flake8 and isort disagree on this order
-from typing import TYPE_CHECKING, Any, Callable, Dict, List  # noqa I101
+from typing import TYPE_CHECKING, Any, Callable, Dict, List
 
 import requests
 


### PR DESCRIPTION
Adds to the `examples/unit` directory a readme file and two sample test cases showing covering testing parameters are valid. 

This includes the additional functionality to support SSM parameter types, which close #270 and complete #202. This also adds the ability to load parameters from configuration files (supporting the CodePipeline artifact and CloudFormation CLI configuration file options). 

I've added in `isort` as a pre-commit hook and changed flake8 to use this for checking import order too to save needing to manually reorder imports. It is pretty much the same check that was there before. When I was recreating my `venv` it was failing to install so I've set the minimum taskcat version to the latest, hope that is ok. 

@shadycuz I suggest that this feature triggers a new release and we explore the naming/hook piece for the release after. 