### PR TITLE
Add the ability to use Cloudformation hosted Tranforms

### DIFF
--- a/src/cloud_radar/cf/unit/test__template.py
+++ b/src/cloud_radar/cf/unit/test__template.py
@@ -1,0 +1,46 @@
+# Just a note that GitHub Copilot generated this entire file, first try
+import pytest
+
+from cloud_radar.cf.unit import functions
+from cloud_radar.cf.unit._template import Template
+
+
+def test_load_allowed_functions_no_transforms():
+    template = Template({})
+    result = template.load_allowed_functions()
+    assert result == functions.ALL_FUNCTIONS
+
+
+def test_load_allowed_functions_single_transform():
+    template = Template({"Transform": "AWS::Serverless-2016-10-31"})
+    result = template.load_allowed_functions()
+    expected = {
+        **functions.ALL_FUNCTIONS,
+        **functions.TRANSFORMS["AWS::Serverless-2016-10-31"],
+    }
+    assert result == expected
+
+
+def test_load_allowed_functions_multiple_transforms():
+    template = Template({"Transform": ["AWS::Serverless-2016-10-31", "AWS::Include"]})
+    result = template.load_allowed_functions()
+    expected = {
+        **functions.ALL_FUNCTIONS,
+        **functions.TRANSFORMS["AWS::Serverless-2016-10-31"],
+        **functions.TRANSFORMS["AWS::Include"],
+    }
+    assert result == expected
+
+
+def test_load_allowed_functions_invalid_transform():
+    template = Template({"Transform": "InvalidTransform"})
+    with pytest.raises(ValueError):
+        template.load_allowed_functions()
+
+
+def test_load_allowed_functions_invalid_transforms():
+    template = Template(
+        {"Transform": ["AWS::Serverless-2016-10-31", "InvalidTransform"]}
+    )
+    with pytest.raises(ValueError):
+        template.load_allowed_functions()

--- a/tests/templates/test_maps.yml
+++ b/tests/templates/test_maps.yml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: "Creates an S3 bucket to store logs."
+
+Transform: AWS::LanguageExtensions
+
+Mappings:
+  Test:
+    Foo:
+      bar: baz
+
+Resources:
+  BazBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !FindInMap [Test, Foo, bar]
+
+  BazingaBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !FindInMap [Test, Foo, baz, DefaultValue: bazinga]

--- a/tests/test_cf/test_examples/test_unit.py
+++ b/tests/test_cf/test_examples/test_unit.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pyexpat
 import pytest
 
 from cloud_radar.cf.unit import Template

--- a/tests/test_cf/test_examples/test_unit.py
+++ b/tests/test_cf/test_examples/test_unit.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pyexpat
 import pytest
 
 from cloud_radar.cf.unit import Template
@@ -8,6 +9,13 @@ from cloud_radar.cf.unit import Template
 @pytest.fixture
 def template():
     template_path = Path(__file__).parent / "../../templates/log_bucket/log_bucket.yaml"
+
+    return Template.from_yaml(template_path.resolve(), {})
+
+
+@pytest.fixture
+def map_template():
+    template_path = Path(__file__).parent / "../../templates/test_maps.yml"
 
     return Template.from_yaml(template_path.resolve(), {})
 
@@ -46,3 +54,15 @@ def test_log_retain(template: Template):
     always_true = stack.get_condition("AlwaysTrue")
 
     always_true.assert_value_is(True)
+
+
+def test_maps(map_template: Template):
+    stack = map_template.create_stack()
+
+    baz_bucket = stack.get_resource("BazBucket")
+
+    baz_bucket.assert_property_has_value("BucketName", "baz")
+
+    bazinga_bucket = stack.get_resource("BazingaBucket")
+
+    bazinga_bucket.assert_property_has_value("BucketName", "bazinga")

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -278,6 +278,33 @@ def test_find_in_map():
     assert result == expected
 
 
+def test_transform_find_in_map():
+    template = {}
+
+    add_metadata(template, Template.Region)
+
+    template = Template(template)
+
+    map_name = "TestMap"
+    first_key = "FirstKey"
+    second_key = "SecondKey"
+    expected = "ExpectedValue"
+
+    values = [map_name, first_key, second_key, {"DefaultValue": "Default"}]
+
+    template.template["Mappings"] = {map_name: {first_key: {second_key: expected}}}
+
+    result = functions.enhanced_find_in_map(template, values)
+
+    assert result == expected
+
+    values = [map_name, first_key, "FakeKey", {"DefaultValue": "Default"}]
+
+    result = functions.enhanced_find_in_map(template, values)
+
+    assert result == "Default"
+
+
 def test_get_att():
     template = {"Resources": {}}
 


### PR DESCRIPTION
This commit adds the groundwork for using Cloudformation hosted Transforms. The Transforms add or enhance the existing Cloudformation functionality.

The only Transform currently supported is the AWS::LanguageExtensions and it is only partially implemented. This commit only adds support for using a DefaultValue when using the !FindInMap function.

Releated to #271 