### PR TITLE
Correct SSM parameter key regex

### DIFF
--- a/examples/unit/parameters/ssm/SSM_Parameter_example.yaml
+++ b/examples/unit/parameters/ssm/SSM_Parameter_example.yaml
@@ -5,7 +5,7 @@ Parameters:
   MyBucket:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Description: The bucket name where all the data will be put into.
-    Default: /my_parameters/bucket/name
+    Default: /product/dev/eu-west-1/import/assets-bucket
 
   MyDatabase:
     Type: 'AWS::SSM::Parameter::Value<String>'

--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -596,7 +596,12 @@ def validate_aws_parameter_constraints(
 
     # There are a few variants of SSM parameters, but they all have the
     # same regex pattern
-    ssm_parameter_value_regex = r"^(/{0,1}(?!/))[A-Za-z0-9/-_]+(.([a-zA-Z]+))?$"
+    #
+    # This is based on the documentation for the PutParameter API operation
+    # https://docs.aws.amazon.com/systems-manager/latest/APIReference/
+    # API_PutParameter.html#systemsmanager-PutParameter-request-Name
+    #
+    ssm_parameter_value_regex = r"^([/]{0,1}[a-zA-Z0-9_.-]*){1,15}$"
 
     if parameter_type.startswith("AWS::SSM::Parameter::Value<"):
         # SSM parameter, need to validate that the type in the angle brackets
@@ -640,7 +645,7 @@ def validate_aws_parameter_constraints(
             raise ValueError(
                 (
                     f"Value {parameter_value} does not match the expected pattern "
-                    f"for SSM parameter {parameter_name}"
+                    f"for SSM parameter {parameter_name}."
                 )
             )
 


### PR DESCRIPTION
Fixes #316 . Updates regex used for validating SSM parameter keys to one that is based on AWS documentation. 