### PR TITLE
Add caching to region data fetching

### DIFF
--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -8,7 +8,8 @@ import base64 as b64
 import ipaddress
 import json
 import re
-from typing import TYPE_CHECKING, Any, Callable, Dict, List  # noqa: I101
+from functools import cache
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional  # noqa: I101
 
 import requests
 
@@ -25,7 +26,7 @@ Dispatch = Dict[str, Callable[..., Any]]
 # The maps are a nested dictionary.
 Mapping = Dict[str, Dict[str, Dict[str, Any]]]
 
-REGION_DATA = None
+REGION_DATA: Optional[List[dict]] = None
 
 
 def base64(_t: "Template", value: Any) -> str:
@@ -877,6 +878,7 @@ def get_region_azs(region_name: str) -> List[str]:
     raise Exception(f"Unable to find region {region_name}.")
 
 
+@cache
 def _fetch_region_data() -> List[dict]:
     """Fetchs Region JSON from URL.
 

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -407,6 +407,15 @@ def test_fetch_region_data(mocker):
 
     mock_r = mock_post.return_value
 
+    mock_r.status_code = 500
+
+    functions._fetch_region_data()
+
+    mock_r.raise_for_status.assert_called()
+
+    # need to reset the mock
+    mock_r.reset_mock()
+
     mock_r.status_code = 200
 
     result = functions._fetch_region_data()
@@ -414,14 +423,6 @@ def test_fetch_region_data(mocker):
     assert result == "TestData"
 
     mock_r.raise_for_status.assert_not_called()
-
-    assert result == "TestData"
-
-    mock_r.status_code = 500
-
-    functions._fetch_region_data()
-
-    mock_r.raise_for_status.assert_called()
 
 
 def test_import_value():


### PR DESCRIPTION
Implement caching for the `_fetch_region_data` function to reduce rate limiting issues encountered when fetching data from GitHub. This change optimizes data retrieval by storing results for subsequent requests.