### PR TITLE
change error handling when fetching regions from github and add user-agent

### DIFF
--- a/src/cloud_radar/cf/unit/_hooks.py
+++ b/src/cloud_radar/cf/unit/_hooks.py
@@ -158,7 +158,6 @@ class HookProcessor:
     ) -> None:
         # Iterate through the resources in the rendered stack
         for logical_id in stack.data.get("Resources", {}):
-            print("Got resource " + logical_id)
             resource_definition = stack.get_resource(logical_id)
 
             resource_type = resource_definition.get("Type")

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -890,7 +890,9 @@ def _fetch_region_data() -> List[dict]:
 
     r = requests.get(url)
 
-    if not r.status_code == requests.codes.ok:
+    if not r.ok:
+        print(f"Failed to fetch region data from {url}.")
+        print(r.text)
         r.raise_for_status()
 
     return json.loads(r.text)

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -888,7 +888,10 @@ def _fetch_region_data() -> List[dict]:
 
     url = "https://raw.githubusercontent.com/jsonmaur/aws-regions/master/regions.json"
 
-    r = requests.get(url)
+    # set user-agent to avoid being throttled
+    headers = {"User-Agent": "cloud-radar"}
+
+    r = requests.get(url, headers=headers)
 
     if not r.ok:
         print(f"Failed to fetch region data from {url}.")

--- a/tests/test_cf/test_unit/test_functions.py
+++ b/tests/test_cf/test_unit/test_functions.py
@@ -408,6 +408,7 @@ def test_fetch_region_data(mocker):
     mock_r = mock_post.return_value
 
     mock_r.status_code = 500
+    mock_r.ok = False
 
     functions._fetch_region_data()
 


### PR DESCRIPTION
At work we were getting 403 denied on AWS, until I changed the user-agent.