### PR TITLE
remove check for nested intrinsic functions

### DIFF
--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -283,9 +283,7 @@ def condition(template: "Template", name: Any) -> bool:
     condition_value = template.template["Conditions"][name]
 
     if not isinstance(condition_value, bool):
-        condition_value: bool = template.resolve_values(  # type: ignore
-            condition_value, allowed_func=ALLOWED_NESTED_CONDITIONS
-        )
+        condition_value: bool = template.resolve_values(condition_value)  # type: ignore
 
     return condition_value
 
@@ -940,106 +938,6 @@ INTRINSICS: Dispatch = {
 ALL_FUNCTIONS: Dispatch = {
     **CONDITIONS,
     **INTRINSICS,
-}
-
-ALLOWED_NESTED_CONDITIONS: Dispatch = {
-    "Fn::FindInMap": find_in_map,
-    "Ref": ref,
-    **CONDITIONS,
-}
-
-# Cloudformation only allows certain functions to be called from inside
-# other functions. The keys are the function name and the values are the
-# functions that are allowed to be nested inside it.
-ALLOWED_FUNCTIONS: Dict[str, Dispatch] = {
-    "Fn::And": ALLOWED_NESTED_CONDITIONS,
-    "Fn::Equals": {**ALLOWED_NESTED_CONDITIONS, "Fn::Join": join, "Fn::Select": select},
-    "Fn::If": {
-        "Fn::Base64": base64,
-        "Fn::FindInMap": find_in_map,
-        "Fn::GetAtt": get_att,
-        "Fn::GetAZs": get_azs,
-        "Fn::If": if_,
-        "Fn::Join": join,
-        "Fn::Select": select,
-        "Fn::Sub": sub,
-        "Ref": ref,
-        "Fn::ImportValue": import_value,
-    },
-    "Fn::Not": ALLOWED_NESTED_CONDITIONS,
-    "Fn::Or": ALLOWED_NESTED_CONDITIONS,
-    "Condition": {},  # Only allows strings
-    "Fn::Base64": ALL_FUNCTIONS,
-    "Fn::Cidr": {
-        "Fn::Select": select,
-        "Ref": ref,
-    },
-    "Fn::FindInMap": {
-        "Fn::FindInMap": find_in_map,
-        "Ref": ref,
-    },
-    "Fn::GetAtt": {},  # This one is complicated =/
-    "Fn::GetAZs": {
-        "Ref": ref,
-    },
-    "Fn::ImportValue": {
-        "Fn::Base64": base64,
-        "Fn::FindInMap": find_in_map,
-        "Fn::If": if_,
-        "Fn::Join": join,
-        "Fn::Select": select,
-        "Fn::Split": split,
-        "Fn::Sub": sub,
-        "Ref": ref,
-    },  # Import value can't depend on resources (not implemented)
-    "Fn::Join": {
-        "Fn::Base64": base64,
-        "Fn::FindInMap": find_in_map,
-        "Fn::GetAtt": get_att,
-        "Fn::GetAZs": get_azs,
-        "Fn::If": if_,
-        "Fn::ImportValue": import_value,
-        "Fn::Join": join,
-        "Fn::Split": split,
-        "Fn::Select": select,
-        "Fn::Sub": sub,
-        "Ref": ref,
-    },
-    "Fn::Select": {
-        "Fn::FindInMap": find_in_map,
-        "Fn::GetAtt": get_att,
-        "Fn::GetAZs": get_azs,
-        "Fn::If": if_,
-        "Fn::Split": split,
-        "Ref": ref,
-    },
-    "Fn::Split": {
-        "Fn::Base64": base64,
-        "Fn::FindInMap": find_in_map,
-        "Fn::GetAtt": get_att,
-        "Fn::GetAZs": get_azs,
-        "Fn::If": if_,
-        "Fn::ImportValue": import_value,
-        "Fn::Join": join,
-        "Fn::Split": split,
-        "Fn::Select": select,
-        "Fn::Sub": sub,
-        "Ref": ref,
-    },
-    "Fn::Sub": {
-        "Fn::Base64": base64,
-        "Fn::FindInMap": find_in_map,
-        "Fn::GetAtt": get_att,
-        "Fn::GetAZs": get_azs,
-        "Fn::If": if_,
-        "Fn::ImportValue": import_value,
-        "Fn::Join": join,
-        "Fn::Select": select,
-        "Ref": ref,
-        "Fn::Sub": sub,
-    },
-    "Fn::Transform": {},  # Transform isn't fully implemented
-    "Ref": {},  # String only.
 }
 
 # Extra functions that are allowed if the template is using a transform.

--- a/src/cloud_radar/cf/unit/test__template.py
+++ b/src/cloud_radar/cf/unit/test__template.py
@@ -7,40 +7,38 @@ from cloud_radar.cf.unit._template import Template
 
 def test_load_allowed_functions_no_transforms():
     template = Template({})
-    result = template.load_allowed_functions()
-    assert result == functions.ALL_FUNCTIONS
+    template.load_allowed_functions()
+    assert template.allowed_functions == functions.ALL_FUNCTIONS
 
 
 def test_load_allowed_functions_single_transform():
     template = Template({"Transform": "AWS::Serverless-2016-10-31"})
-    result = template.load_allowed_functions()
+    template.load_allowed_functions()
     expected = {
         **functions.ALL_FUNCTIONS,
         **functions.TRANSFORMS["AWS::Serverless-2016-10-31"],
     }
-    assert result == expected
+    assert template.allowed_functions == expected
 
 
 def test_load_allowed_functions_multiple_transforms():
     template = Template({"Transform": ["AWS::Serverless-2016-10-31", "AWS::Include"]})
-    result = template.load_allowed_functions()
+    template.load_allowed_functions()
     expected = {
         **functions.ALL_FUNCTIONS,
         **functions.TRANSFORMS["AWS::Serverless-2016-10-31"],
         **functions.TRANSFORMS["AWS::Include"],
     }
-    assert result == expected
+    assert template.allowed_functions == expected
 
 
 def test_load_allowed_functions_invalid_transform():
-    template = Template({"Transform": "InvalidTransform"})
+
     with pytest.raises(ValueError):
-        template.load_allowed_functions()
+        Template({"Transform": "InvalidTransform"})
 
 
 def test_load_allowed_functions_invalid_transforms():
-    template = Template(
-        {"Transform": ["AWS::Serverless-2016-10-31", "InvalidTransform"]}
-    )
+
     with pytest.raises(ValueError):
-        template.load_allowed_functions()
+        Template({"Transform": ["AWS::Serverless-2016-10-31", "InvalidTransform"]})

--- a/tests/test_cf/test_unit/test_template.py
+++ b/tests/test_cf/test_unit/test_template.py
@@ -124,60 +124,28 @@ def test_resolve():
 
     template = Template(t)
 
-    result = template.resolve_values({"Ref": "Test"}, functions.ALL_FUNCTIONS)
+    result = template.resolve_values({"Ref": "Test"})
 
     assert result == "test", "Should resolve the value from the template."
 
     with pytest.raises(Exception) as ex:
-        result = template.resolve_values({"Ref": "Test2"}, functions.ALL_FUNCTIONS)
+        result = template.resolve_values({"Ref": "Test2"})
 
     assert "not a valid Resource" in str(ex)
 
-    result = template.resolve_values(
-        {"level1": {"Fn::If": ["test", "True", "False"]}}, functions.ALL_FUNCTIONS
-    )
+    result = template.resolve_values({"level1": {"Fn::If": ["test", "True", "False"]}})
 
     assert result == {"level1": "True"}, "Should resolve nested dicts."
 
     result = template.resolve_values(
-        [{"level1": {"Fn::If": ["test", "True", "False"]}}], functions.ALL_FUNCTIONS
+        [{"level1": {"Fn::If": ["test", "True", "False"]}}]
     )
 
     assert result == [{"level1": "True"}], "Should resolve nested lists."
 
-    result = template.resolve_values("test", functions.ALL_FUNCTIONS)
+    result = template.resolve_values("test")
 
     assert result == "test", "Should return regular strings."
-
-
-def test_function_order():
-    t = {
-        "Parameters": {"Test": {"Type": "String", "Value": "test"}},
-        "Conditions": {"test": True},
-    }
-
-    template = Template(t)
-
-    test_if = {
-        "Fn::Cidr": {
-            "Fn::If": "select",
-        }
-    }
-
-    with pytest.raises(ValueError) as ex:
-        _ = template.resolve_values(test_if, functions.ALL_FUNCTIONS)
-
-    assert "Fn::If with value" in str(ex)
-
-    with pytest.raises(ValueError) as ex:
-        _ = template.resolve_values({"Fn::Base64": ""}, functions.CONDITIONS)
-
-    assert "Fn::Base64 with value" in str(ex)
-
-    with pytest.raises(ValueError) as ex:
-        _ = template.resolve_values({"Fn::Not": ""}, functions.INTRINSICS)
-
-    assert "Fn::Not with value" in str(ex)
 
 
 def test_set_params():


### PR DESCRIPTION
This feature was based on the nested function limitations in the AWS CloudFormation documentation. However, in turns out that the AWS documentation is incorrect and nested functions are allowed in many places where the documentation says they are not. Since this feature was doing more harm than good, it has been removed.