### PR TITLE
fix(params): change error messages to include parameter names #171

### DIFF
--- a/src/cloud_radar/cf/unit/_template.py
+++ b/src/cloud_radar/cf/unit/_template.py
@@ -232,7 +232,6 @@ class Template:
             return {**functions.ALL_FUNCTIONS, **transform_functions}
 
         if isinstance(self.transforms, list):
-
             transform_functions = {}
 
             for transform in self.transforms:
@@ -505,8 +504,14 @@ class Template:
 
         t_params: dict = self.template["Parameters"]
 
-        if set(parameters) - set(t_params):
-            raise ValueError("You passed a Parameter that was not in the Template.")
+        params_not_in_template = set(parameters) - set(t_params)
+        if params_not_in_template:
+            raise ValueError(
+                (
+                    "You supplied one or more Parameters that were not in the "
+                    f"Template - {params_not_in_template}"
+                )
+            )
 
         for p_name, p_value in t_params.items():
             if p_name in parameters:
@@ -519,7 +524,10 @@ class Template:
 
             if "Default" not in p_value:
                 raise ValueError(
-                    "Must provide values for parameters that don't have a default value."
+                    (
+                        f'Must provide values for parameter "{p_name}" '
+                        "that does not have a default value."
+                    )
                 )
 
             t_params[p_name]["Value"] = p_value["Default"]

--- a/tests/test_cf/test_unit/test_template.py
+++ b/tests/test_cf/test_unit/test_template.py
@@ -173,12 +173,11 @@ def test_set_params():
         }
     }
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(
+        ValueError,
+        match=r"Must provide values for parameter \"Test\" that does not have a default value.",
+    ):
         template.set_parameters()
-
-    assert "Must provide values for parameters that don't have a default value." in str(
-        e.value
-    ), "Should throw correct exception."
 
     template.set_parameters({"Test": "value"})
 
@@ -186,12 +185,11 @@ def test_set_params():
         "Parameters"
     ], "Should set the value to what we pass in."
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(
+        ValueError,
+        match=r"You supplied one or more Parameters that were not in the Template - {'Bar'}",
+    ):
         template.set_parameters({"Bar": "Foo"})
-
-    assert "You passed a Parameter that was not in the Template." in str(
-        e.value
-    ), "Should throw correct exception."
 
     template.template = {"Parameters": {"Test": {"Default": "default"}}}
 


### PR DESCRIPTION
Fixes #171 

Improves error messages to include the names of the parameters which are incorrect. 