### PR TITLE
Feat/allow override ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ dynamic_references = {
 template = Template(template_content, dynamic_references=dynamic_references)
 ```
 
-There are cases where the default behaviour of our `GetAtt` implementation may not be sufficient and you need a more accurate returned value. When unit testing there are no real AWS resources created, and cloud-radar does not attempt to realistically generate attribute values - a string is always returned. This works good enough most of the time, but there are some cases where if you are attempting to apply intrinsic functions against the attribute value it needs to be more correct. When this occurs, you can add Metadata to the template to provide test values to use.
+There are cases where the default behaviour of our `Ref` and `GetAtt` implementations may not be sufficient and you need a more accurate returned value. When unit testing there are no real AWS resources created, and cloud-radar does not attempt to realistically generate attribute values - a string is always returned. For `Ref` this is the logical resource name, for `GetAtt` this is `<logical resource name>.<attribute name>`. This works good enough most of the time, but there are some cases where if you are attempting to apply intrinsic functions against these value it needs to be more correct. When this occurs, you can add Metadata to the template to provide test values to use.
 
 ```
 Resources:
@@ -219,6 +219,7 @@ Resources:
     Type: AWS::MediaPackageV2::Channel
     Metadata:
       Cloud-Radar:
+        ref: arn:aws:mediapackagev2:region:AccountId:ChannelGroup/ChannelGroupName/Channel/ChannelName
         attribute-values:
         # Default behaviour of a string is not good enough here, the attribute value is expected to be a List.
           IngestEndpointUrls:
@@ -228,6 +229,7 @@ Resources:
       ChannelGroupName: dev_video_1
       ChannelName: !Sub ${AWS::StackName}-MediaPackageChannel
 ```
+If you are unable to modify the template itself, it is also possible to inject this metadata as part of the unit test. See [this test case](./tests/test_cf/test_unit/test_functions_ref.py) for an example.
 
 A real unit testing example using Pytest can be seen [here](./tests/test_cf/test_examples/test_unit.py)
 

--- a/src/cloud_radar/cf/unit/_output.py
+++ b/src/cloud_radar/cf/unit/_output.py
@@ -27,11 +27,12 @@ class Output(UserDict):
         Args:
             value (Any): The value to compare the output value to.
         """
-        acutal_value = self.get_value()
+        actual_value = self.get_value()
 
-        assert (
-            value == acutal_value
-        ), f"Output '{self.name}' actual value did not match input value."
+        assert value == actual_value, (
+            f"Output '{self.name}' actual value ({actual_value}) did not match"
+            f" input value ({value})."
+        )
 
     def has_export(self):
         """Check if the output has an export."""

--- a/tests/templates/test_imagebuilder_image_ref.yaml
+++ b/tests/templates/test_imagebuilder_image_ref.yaml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: "Basic template to check Ref behaviours"
+
+Resources:
+  DummyEcrImage:
+    Type: AWS::ImageBuilder::Image
+    Properties:
+      ContainerRecipeArn: "ContainerRecipeArn"
+      EnhancedImageMetadataEnabled: true
+      InfrastructureConfigurationArn: "InfrastructureConfigurationArn"
+      ImageTestsConfiguration:
+        ImageTestsEnabled: false
+  MediaPackageV2Channel:
+    Type: AWS::MediaPackageV2::Channel
+    Properties:
+      ChannelGroupName: dev_video_1
+      ChannelName: !Sub ${AWS::StackName}-MediaPackageChannel
+
+
+Outputs:
+  ImageArn:
+    Description: The image ARN
+    Value: !Ref DummyEcrImage
+  ImageName:
+    Description: The name part of the image ARN
+    Value: !Select [1, !Split ['/', !Ref DummyEcrImage]]
+  ChannelArn:
+    Description: The name part of the image ARN
+    Value: !Ref MediaPackageV2Channel

--- a/tests/test_cf/test_unit/test_functions_ref.py
+++ b/tests/test_cf/test_unit/test_functions_ref.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cloud_radar.cf.unit._template import Template
+
+"""Tests that the Ref function can use metadata defined in a template."""
+
+
+@pytest.fixture
+def template():
+    template_path = (
+        Path(__file__).parent / "../../templates/test_imagebuilder_image_ref.yaml"
+    )
+
+    return Template.from_yaml(template_path.resolve(), {})
+
+
+def test_outputs(template: Template):
+    # As well as setting the resource metadata in the template file itself, we can
+    # programmatically do the same thing
+    image_arn = "arn:aws:imagebuilder:us-west-2:123456789012:image/my-example-image"
+    metadata = {"Cloud-Radar": {"ref": image_arn}}
+    template.template["Resources"]["DummyEcrImage"]["Metadata"] = metadata
+
+    # When rendering the stack, it reloads the "raw" so need to reset that back with the modified content
+    template.raw = yaml.dump(template.template)
+
+    stack = template.create_stack()
+
+    # These outputs are expected to use the metadata override
+    stack.get_output("ImageArn").assert_value_is(image_arn)
+    stack.get_output("ImageName").assert_value_is("my-example-image")
+
+    # This attribute will use the default format
+    stack.get_output("ChannelArn").assert_value_is("MediaPackageV2Channel")

--- a/tests/test_cf/test_unit/test_output.py
+++ b/tests/test_cf/test_unit/test_output.py
@@ -52,7 +52,7 @@ def test_output_assert_value_is(stack: Stack):
 
     with pytest.raises(
         AssertionError,
-        match="Output 'LogsBucketName' actual value did not match input value.",
+        match="Output 'LogsBucketName' actual value \(LogsBucket\) did not match input value \(test-logs-bucket2\).",
     ):
         output.assert_value_is("test-logs-bucket2")
 


### PR DESCRIPTION
Fixes #414, fixes #415, fixes #410

Adds support for overriding the value for `!Ref` through resource metadata, and updates test cases and documentation to include how this can be done without modifying the actual template itself