### PR TITLE
fix(sub): handle case where a parameter has a default value of a number

### DIFF
--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -714,7 +714,7 @@ def sub_s(template: "Template", value: str) -> str:
         else:
             result = ref(template, var)
 
-        return result
+        return str(result)
 
     reVar = r"(?!\$\{\!)\$\{(\w+[^}]*)\}"
 

--- a/tests/templates/test_sub_default_number.yaml
+++ b/tests/templates/test_sub_default_number.yaml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+    pTargetDatabaseClusterNumber:
+      Type: Number
+      Description: The number of the Aurora Cluster where the database is hosted
+      Default: 1
+    pProduct:
+      Type: String
+      Description: The resources are part of which product
+      Default: dummy
+Resources:
+  rFunctionSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub '${pProduct}-${AWS::Region}-lmb-sg'
+      GroupDescription: Lambda security group
+      VpcId:  !Sub '{{resolve:ssm:/${pProduct}/dev/${AWS::Region}/vpc/id/horizontal-vpc}}'
+      SecurityGroupEgress:
+        - IpProtocol: 'tcp'
+          DestinationSecurityGroupId: !Sub '{{resolve:ssm:/${pProduct}/dev/${AWS::Region}/aurora/cluster/${pTargetDatabaseClusterNumber}/sec-grp/id}}'
+          Description: !Sub 'RDS Access to cluster ${pTargetDatabaseClusterNumber}'
+          FromPort: 5432
+          ToPort: 5432

--- a/tests/test_cf/test_unit/test_functions_sub.py
+++ b/tests/test_cf/test_unit/test_functions_sub.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cloud_radar.cf.unit._template import Template
+
+"""Tests some edge cases for the Sub function"""
+
+
+@pytest.fixture
+def template():
+    template_path = (
+        Path(__file__).parent / "../../templates/test_sub_default_number.yaml"
+    )
+
+    return Template.from_yaml(
+        template_path.resolve(),
+        dynamic_references={
+            "ssm": {
+                "/dummy/dev/us-east-1/aurora/cluster/1/sec-grp/id": "sg-1234567",
+                "/dummy/dev/us-east-1/aurora/cluster/2/sec-grp/id": "sg-7654321",
+                "/dummy/dev/us-east-1/vpc/id/horizontal-vpc": "vpc-123456",
+            }
+        },
+    )
+
+
+def test_with_default_number(template: Template):
+    stack = template.create_stack()
+
+    # Check our value resolved. Not really required, as it will have
+    # errorred before it gets this far if it couldn't find the lookup value
+    security_group_resource = stack.get_resource("rFunctionSecurityGroup")
+    security_group_egress = security_group_resource.get_property_value(
+        "SecurityGroupEgress"
+    )
+
+    assert len(security_group_egress) == 1
+    assert security_group_egress[0]["DestinationSecurityGroupId"] == "sg-1234567"
+
+
+def test_with_supplied_value(template: Template):
+    stack = template.create_stack(params={"pTargetDatabaseClusterNumber": "2"})
+
+    # Check our value resolved. Not really required, as it will have
+    # errorred before it gets this far if it couldn't find the lookup value
+    security_group_resource = stack.get_resource("rFunctionSecurityGroup")
+    security_group_egress = security_group_resource.get_property_value(
+        "SecurityGroupEgress"
+    )
+
+    assert len(security_group_egress) == 1
+    assert security_group_egress[0]["DestinationSecurityGroupId"] == "sg-7654321"


### PR DESCRIPTION
Fixes #448

Ensures values as converted to strings before being used in the replacement