### PR TITLE
Feat/647 add support for remaining languageextensions functions

### DIFF
--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -572,6 +572,32 @@ def join(_t: "Template", values: Any) -> str:
     return delimiter.join(items)
 
 
+def length(_t: "Template", values: Any) -> int:
+    """Solves AWS Length intrinsic function.
+
+    References:
+        https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-length.html
+        https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/transform-aws-languageextensions.html
+
+    Args:
+        _t (Template): Not used.
+        values (Any): The values passed to the function.
+
+    Raises:
+        TypeError: If values is not a List.
+
+    Returns:
+        int: The number of items in the List.
+    """
+
+    if not isinstance(values, list):
+        raise TypeError(
+            f"Fn::Length - The value must be a List, not {type(values).__name__}."
+        )
+
+    return len(values)
+
+
 def select(_t: "Template", values: Any) -> Any:
     """Solves AWS Select intrinsic function.
 
@@ -955,6 +981,7 @@ TRANSFORMS: Dict[str, Dispatch] = {
     "AWS::Include": {},
     "AWS::LanguageExtensions": {
         "Fn::FindInMap": enhanced_find_in_map,
+        "Fn::Length": length,
     },
     "AWS::SecretsManager-2020-07-23": {},
     "AWS::Serverless-2016-10-31": {},

--- a/src/cloud_radar/cf/unit/functions.py
+++ b/src/cloud_radar/cf/unit/functions.py
@@ -598,6 +598,33 @@ def length(_t: "Template", values: Any) -> int:
     return len(values)
 
 
+def to_json_string(_t: "Template", value: Any) -> str:
+    """Solves AWS ToJsonString intrinsic function.
+
+    References:
+        https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-ToJsonString.html
+        https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/transform-aws-languageextensions.html
+
+    Args:
+        _t (Template): Not used.
+        value (Any): The object or array to convert to a JSON string.
+
+    Raises:
+        TypeError: If value is not a Dict or List.
+
+    Returns:
+        str: The value converted to a JSON string.
+    """
+
+    if not isinstance(value, (dict, list)):
+        raise TypeError(
+            "Fn::ToJsonString - The value must be a Dict or List, not "
+            f"{type(value).__name__}."
+        )
+
+    return json.dumps(value, separators=(",", ":"))
+
+
 def select(_t: "Template", values: Any) -> Any:
     """Solves AWS Select intrinsic function.
 
@@ -982,6 +1009,7 @@ TRANSFORMS: Dict[str, Dispatch] = {
     "AWS::LanguageExtensions": {
         "Fn::FindInMap": enhanced_find_in_map,
         "Fn::Length": length,
+        "Fn::ToJsonString": to_json_string,
     },
     "AWS::SecretsManager-2020-07-23": {},
     "AWS::Serverless-2016-10-31": {},

--- a/tests/templates/test_length.yaml
+++ b/tests/templates/test_length.yaml
@@ -1,0 +1,37 @@
+# Example template from
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/transform-aws-languageextensions.html#aws-languageextensions-examples
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::LanguageExtensions
+Parameters:
+  QueueList:
+    Type: CommaDelimitedList
+  QueueNameParam:
+    Description: Name for your SQS queue
+    Type: String
+
+Conditions:
+  cIsLarge:
+    !Equals
+      - 'Fn::Length': !Ref QueueList
+      - 3
+Resources:
+  Queue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Ref QueueNameParam
+      DelaySeconds:
+        'Fn::Length': !Ref QueueList
+
+  QueueTwo:
+    Type: AWS::SQS::Queue
+    Condition: cIsLarge
+    Properties:
+      QueueName: !Sub '${QueueNameParam}-Large'
+      DelaySeconds:
+        'Fn::Length': !Ref QueueList
+
+Outputs:
+  QueueListLength:
+    Description: The length of the supplied queue list
+    Value:
+      'Fn::Length': !Ref QueueList

--- a/tests/test_cf/test_unit/test_functions_length.py
+++ b/tests/test_cf/test_unit/test_functions_length.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pytest
+
+from cloud_radar.cf.unit import functions
+from cloud_radar.cf.unit._template import Template
+
+"""Tests that the LanguageExtension Length function works as expected"""
+
+
+@pytest.fixture
+def template():
+    template_path = Path(__file__).parent / "../../templates/test_length.yaml"
+
+    return Template.from_yaml(template_path.resolve(), {})
+
+
+def test_small(template: Template):
+    stack = template.create_stack(
+        params={"QueueNameParam": "MyQueue", "QueueList": "A,B"}
+    )
+
+    # Check the created resource has the expected property value
+    queue_resource = stack.get_resource("Queue")
+    queue_resource.assert_property_has_value("DelaySeconds", 2)
+
+    # Check the condition resolved to the expected false
+    stack.no_resource("QueueTwo")
+
+    # Check the output has the expected value
+    stack.get_output("QueueListLength").assert_value_is(2)
+
+
+def test_direct_list_input():
+    template = Template(
+        {
+            "Transform": "AWS::LanguageExtensions",
+            "Outputs": {"ListLength": {"Value": {"Fn::Length": ["A", "B", "C"]}}},
+        }
+    )
+
+    stack = template.create_stack()
+
+    stack.get_output("ListLength").assert_value_is(3)
+
+
+def test_invalid_input_type_raises():
+    template = Template({})
+
+    with pytest.raises(TypeError) as e:
+        functions.length(template, "A,B")
+
+    assert "Fn::Length - The value must be a List, not str." in str(e.value)

--- a/tests/test_cf/test_unit/test_functions_tojsonstring.py
+++ b/tests/test_cf/test_unit/test_functions_tojsonstring.py
@@ -1,0 +1,68 @@
+"""Tests for the AWS::LanguageExtensions Fn::ToJsonString intrinsic.
+
+AWS references:
+https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-ToJsonString.html
+https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/transform-aws-languageextensions.html
+"""
+
+from cloud_radar.cf.unit._template import Template
+
+
+def test_object_to_json_string():
+    """Based on the AWS object example using a nested Ref."""
+
+    template = Template(
+        {
+            "Transform": "AWS::LanguageExtensions",
+            "Parameters": {"ParameterName": {"Type": "String"}},
+            "Outputs": {
+                "JsonString": {
+                    "Value": {
+                        "Fn::ToJsonString": {
+                            "key1": "value1",
+                            "key2": {"Ref": "ParameterName"},
+                        }
+                    }
+                }
+            },
+        }
+    )
+
+    stack = template.create_stack(params={"ParameterName": "resolvedValue"})
+
+    stack.get_output("JsonString").assert_value_is(
+        '{"key1":"value1","key2":"resolvedValue"}'
+    )
+
+
+def test_array_to_json_string():
+    """Uses the AWS array form, with the expected JSON inferred from the input.
+
+    The AWS page's rendered output for the array example appears inconsistent
+    with its input, so this test follows the documented behavior: an array
+    should be converted to the corresponding JSON string after nested
+    intrinsics are resolved.
+    """
+
+    template = Template(
+        {
+            "Transform": "AWS::LanguageExtensions",
+            "Parameters": {"ParameterName": {"Type": "String"}},
+            "Outputs": {
+                "JsonString": {
+                    "Value": {
+                        "Fn::ToJsonString": [
+                            {"key1": "value1"},
+                            {"key2": {"Ref": "ParameterName"}},
+                        ]
+                    }
+                }
+            },
+        }
+    )
+
+    stack = template.create_stack(params={"ParameterName": "resolvedValue"})
+
+    stack.get_output("JsonString").assert_value_is(
+        '[{"key1":"value1"},{"key2":"resolvedValue"}]'
+    )


### PR DESCRIPTION
Fixes #647 

Adds support for the Length and ToJsonString intrinsic functions. Tests are all based on the AWS documentation as these are not features I use directly. 